### PR TITLE
Add a BuildableFunctionView allowing statically rendered function views.

### DIFF
--- a/bakery/views/__init__.py
+++ b/bakery/views/__init__.py
@@ -2,6 +2,7 @@ from .base import (
     BuildableMixin,
     BuildableTemplateView,
     Buildable404View,
+    BuildableFunctionView,
     BuildableRedirectView
 )
 from .detail import BuildableDetailView
@@ -17,6 +18,7 @@ __all__ = (
     'BuildableMixin',
     'BuildableTemplateView',
     'Buildable404View',
+    'BuildableFunctionView',
     'BuildableRedirectView',
     'BuildableDetailView',
     'BuildableListView',


### PR DESCRIPTION
There are some cases where building off of models and templates isn't
workable. A good example of this is a sitemap.xml.

This commit brings in a class which can render most Django function
views assuming it returns either a String or a HttpResponse.

Fixes #130.