### PR TITLE
Add pagination

### DIFF
--- a/bakery/tests/__init__.py
+++ b/bakery/tests/__init__.py
@@ -317,7 +317,6 @@ class BakeryTest(TestCase):
         os.remove(page_2_path)
         os.remove(page_3_path)
 
-
     def test_detail_view(self):
         v = views.BuildableDetailView(
             queryset=MockObject.objects.all(),

--- a/bakery/tests/__init__.py
+++ b/bakery/tests/__init__.py
@@ -268,6 +268,56 @@ class BakeryTest(TestCase):
         self.assertTrue(os.path.exists(build_path))
         os.remove(build_path)
 
+    def test_list_view_with_pagination(self):
+        v = views.BuildableListView(
+            queryset=[1, 2, 3],
+            template_name='listview.html',
+            build_path='foo.html',
+        )
+        v.paginate_by = 2
+        v.build_method()
+        page_default_path = os.path.join(settings.BUILD_DIR, 'foo.html')
+        page_1_path = os.path.join(settings.BUILD_DIR, 'page', '1', 'foo.html')
+        page_2_path = os.path.join(settings.BUILD_DIR, 'page', '2', 'foo.html')
+        self.assertTrue(os.path.exists(page_default_path))
+        self.assertTrue(os.path.exists(page_1_path))
+        self.assertTrue(os.path.exists(page_2_path))
+        os.remove(page_default_path)
+        os.remove(page_1_path)
+        os.remove(page_2_path)
+
+        v = views.BuildableListView(
+            queryset=[1, 2, 3, 4, 5, 6, 7, 8, 9],
+            template_name='listview.html',
+            build_path='foo.html',
+        )
+        v.paginate_by = 7
+        v.build_method()
+        page_default_path = os.path.join(settings.BUILD_DIR, 'foo.html')
+        page_1_path = os.path.join(settings.BUILD_DIR, 'page', '1', 'foo.html')
+        page_2_path = os.path.join(settings.BUILD_DIR, 'page', '2', 'foo.html')
+        self.assertTrue(os.path.exists(page_default_path))
+        self.assertTrue(os.path.exists(page_1_path))
+        self.assertTrue(os.path.exists(page_2_path))
+        os.remove(page_default_path)
+        os.remove(page_1_path)
+        os.remove(page_2_path)
+        v.paginate_by = 3
+        v.build_method()
+        page_default_path = os.path.join(settings.BUILD_DIR, 'foo.html')
+        page_1_path = os.path.join(settings.BUILD_DIR, 'page', '1', 'foo.html')
+        page_2_path = os.path.join(settings.BUILD_DIR, 'page', '2', 'foo.html')
+        page_3_path = os.path.join(settings.BUILD_DIR, 'page', '3', 'foo.html')
+        self.assertTrue(os.path.exists(page_default_path))
+        self.assertTrue(os.path.exists(page_1_path))
+        self.assertTrue(os.path.exists(page_2_path))
+        self.assertTrue(os.path.exists(page_3_path))
+        os.remove(page_default_path)
+        os.remove(page_1_path)
+        os.remove(page_2_path)
+        os.remove(page_3_path)
+
+
     def test_detail_view(self):
         v = views.BuildableDetailView(
             queryset=MockObject.objects.all(),

--- a/bakery/views/list.py
+++ b/bakery/views/list.py
@@ -29,16 +29,62 @@ class BuildableListView(ListView, BuildableMixin):
         template_name:
             The name of the template you would like Django to render. You need
             to override this if you don't want to rely on the Django defaults.
+
+    Pagination is handled like a django ListView, and templates should be
+    designed in the same way.
+    When pagination is enabled the default build locations for the first page
+    are: build_folder/build_path and /build_folder/build_page_name/1/build_path,
+    with other pages only built in:
+    /build_folder/build_page_name/<page_number>/build_path
     """
+    build_folder = ''
+    build_page_name = "page"
     build_path = 'index.html'
+
 
     @property
     def build_method(self):
-        return self.build_queryset
+        if self.get_paginate_by(self.queryset):
+            return self.build_pagination
+        else:
+            return self.build_queryset
+
+    def build_pagination(self):
+        """
+        If pagination is enabled, build the queryset for each page.
+        """
+        number_of_pages = math.ceil(len(self.queryset) / self.paginate_by)
+        if not hasattr(self, "kwargs"):
+            self.kwargs = {}
+        for page in range(0, number_of_pages + 1):
+            self.kwargs['page'] = page
+            self.build_queryset()
+
+    def get_page_build_path(self):
+        """
+        Create the path to build each page in pagination
+        Defaults to building in:
+        <build_folder>/<build_page_name>/<page>/<build_path>
+        The current page is held in self.kwargs['page']
+        """
+        build_path = path.join( self.build_folder,
+                                self.build_page_name,
+                                str(self.kwargs['page']),
+                                self.build_path)
+        return build_path
+
+    def get_build_path(self):
+        build_path = ''
+        if self.get_paginate_by(self.queryset):
+            build_path = self.get_page_build_path()
+        else:
+            build_path = path.join(self.build_folder, self.build_path)
+        return build_path
+
 
     def build_queryset(self):
-        logger.debug("Building %s" % self.build_path)
-        self.request = self.create_request(self.build_path)
-        self.prep_directory(self.build_path)
-        target_path = path.join(settings.BUILD_DIR, self.build_path)
+        logger.debug("Building %s" % self.get_build_path())
+        self.request = self.create_request(self.get_build_path())
+        self.prep_directory(self.get_build_path())
+        target_path = path.join(settings.BUILD_DIR, self.get_build_path())
         self.build_file(target_path, self.get_content())

--- a/docs/buildableviews.rst
+++ b/docs/buildableviews.rst
@@ -49,6 +49,10 @@ BuildableListView
     Render and builds a page about a list of objects. Extended from Django's
     generic `ListView <https://docs.djangoproject.com/en/dev/ref/class-based-views/generic-display/#django.views.generic.list.ListView>`_.
     The base class has a number of options not documented here you should consult.
+    Pagination is handled like a django ListView, and templates should be
+    designed in the same way.
+    When pagination is enabled the default build locations for the first page are: build_folder/build_path and /build_folder/build_page_name/1/build_path, with other pages only built in:
+    /build_folder/build_page_name/<page_number>/build_path
 
     .. attribute:: model
 
@@ -62,6 +66,19 @@ BuildableListView
         any iterable of items, not just a Django queryset. Optional, but
         if this attribute is not defined the ``model`` attribute must be
         defined.
+
+    .. attribute:: build_folder
+
+        The target location of the flat file in the ``BUILD_DIR``.
+        Optional. The default is blank,  would place the flat file
+        at the site's root. Defining it as ``foo/`` would place
+        the flat file inside a subdirectory foo/.
+
+    .. attribute:: build_page_name
+
+        The target location of the flat file in the ``BUILD_DIR``.
+        Optional. The default is ``page``,  would place the page file
+        in /page/1/<build_path>, /page/2/<build_path>.
 
     .. attribute:: build_path
 
@@ -79,6 +96,14 @@ BuildableListView
     .. py:attribute:: build_method
 
         An alias to the ``build_queryset`` method used by the :doc:`management commands </managementcommands>`
+
+    .. py:method:: get_page_build_path()
+
+        Create the path to build each page in pagination
+        Defaults to building in:
+        <build_folder>/<build_page_name>/<page>/<build_path>
+        The current page is held in self.kwargs['page']
+
 
     .. py:method:: build_queryset()
 


### PR DESCRIPTION
Fixes #59

Pagination is handled like a django ListView, and templates should be designed in the same way.
When pagination is enabled the default build locations for the first page are: build_folder/build_path and /build_folder/build_page_name/1/build_path, with other pages only built in: /build_folder/build_page_name/<page_number>/build_path