### PR TITLE
Update link to Tarbell

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -60,7 +60,7 @@ Considering alternatives
 ------------------------
 
 If you are seeking to "bake" out a very simple site, maybe you don't have a database or only a single page, it is quicker
-to try `Tarbell <http://tarbell.tribapps.com/>`_ or `Frozen-Flask <https://pythonhosted.org/Frozen-Flask/>`_, which don't require all
+to try `Tarbell <https://github.com/tarbell-project/tarbell>`_ or `Frozen-Flask <https://pythonhosted.org/Frozen-Flask/>`_, which don't require all
 the overhead of a full Django installation.
 
 This library is better to suited for projects that require a database, want to take advantage of other Django features (like the administration panel)


### PR DESCRIPTION
The old link is redirecting to an adult content site.
The project seems to be abandoned but maybe keeping the link to the repo isn't a bad idea.