### PR TITLE
Remove ifnotequal from static_views.py

### DIFF
--- a/bakery/static_views.py
+++ b/bakery/static_views.py
@@ -96,9 +96,9 @@ DEFAULT_DIRECTORY_INDEX_TEMPLATE = """
   <body>
     <h1>Index of {{ directory }}</h1>
     <ul>
-      {% ifnotequal directory "/" %}
+      {% if directory != "/" %}
       <li><a href="../">../</a></li>
-      {% endifnotequal %}
+      {% endif %}
       {% for f in file_list %}
       <li><a href="{{ f|urlencode }}">{{ f }}</a></li>
       {% endfor %}


### PR DESCRIPTION
`ifnotequal` template tag has been [removed](https://docs.djangoproject.com/en/5.1/releases/4.0/) in Django 4.0