### PR TITLE
Replace PyFilesystem2 with fsspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # AI tools
 .claude
+.goals/
 
 # Python bytecode and caches
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to django-bakery are documented here. The format follows
 
 - Keep filesystem output paths rooted when using Windows drive roots and empty
   build-directory settings.
+- Reject unrooted filesystem root operations and unsupported legacy filesystem
+  plugin URLs.
 ### Removed
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to django-bakery are documented here. The format follows
 
 - Modernize repository quality checks, editor settings, and documentation
   tooling.
+- Replace PyFilesystem2 with fsspec for documented local and memory output
+  backends.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ All notable changes to django-bakery are documented here. The format follows
 
 ### Fixed
 
+- Keep filesystem output paths rooted when using Windows drive roots and empty
+  build-directory settings.
 ### Removed
 
 ### Security

--- a/bakery/apps.py
+++ b/bakery/apps.py
@@ -1,8 +1,9 @@
 import logging
 
-import fs
 from django.apps import AppConfig
 from django.conf import settings
+
+from bakery.filesystem import RootedFilesystem
 
 logger = logging.getLogger(__name__)
 
@@ -11,4 +12,4 @@ class BakeryConfig(AppConfig):
     name = "bakery"
     verbose_name = "Bakery"
     filesystem_name = getattr(settings, "BAKERY_FILESYSTEM", "osfs:///")
-    filesystem = fs.open_fs(filesystem_name)
+    filesystem = RootedFilesystem.from_url(filesystem_name)

--- a/bakery/feeds.py
+++ b/bakery/feeds.py
@@ -79,6 +79,6 @@ class BuildableFeed(Feed, BuildableMixin):
 
             typed_build_path = cast("BuildPath", build_path)
             path = self.get_output_path(typed_build_path)
-            self.prep_directory(path)
+            self.prep_directory(typed_build_path)
             content = self._get_bakery_dynamic_attr("get_content", obj)
             self.build_file(path, cast("bytes", content))

--- a/bakery/feeds.py
+++ b/bakery/feeds.py
@@ -1,9 +1,7 @@
 import logging
 from os import PathLike
-from pathlib import Path
 from typing import TypeAlias, cast
 
-from django.conf import settings
 from django.contrib.syndication.views import Feed
 
 from bakery.views import BuildableMixin
@@ -80,7 +78,7 @@ class BuildableFeed(Feed, BuildableMixin):
             )
 
             typed_build_path = cast("BuildPath", build_path)
-            self.prep_directory(typed_build_path)
-            path = str(Path(settings.BUILD_DIR) / typed_build_path)
+            path = self.get_output_path(typed_build_path)
+            self.prep_directory(path)
             content = self._get_bakery_dynamic_attr("get_content", obj)
             self.build_file(path, cast("bytes", content))

--- a/bakery/filesystem.py
+++ b/bakery/filesystem.py
@@ -47,6 +47,10 @@ class RootedFilesystem:
             url = f"file://{url.removeprefix('osfs://')}"
         elif url.startswith("mem://"):
             url = f"memory://{url.removeprefix('mem://')}"
+        else:
+            raise ValueError(
+                "BAKERY_FILESYSTEM must use a supported osfs:/// or mem:// URL."
+            )
         filesystem, root = url_to_fs(url)
         return cls(cast("_Filesystem", filesystem), cast("str", root))
 

--- a/bakery/filesystem.py
+++ b/bakery/filesystem.py
@@ -1,6 +1,7 @@
 """Rooted filesystem support for bakery output."""
 
 import posixpath
+import re
 from collections.abc import Iterator
 from os import PathLike
 from typing import BinaryIO, Protocol, cast
@@ -37,7 +38,7 @@ class RootedFilesystem:
 
     def __init__(self, filesystem: _Filesystem, root: str = "") -> None:
         self.filesystem = filesystem
-        self.root = root.rstrip("/")
+        self.root = self._normalize_root(root)
 
     @classmethod
     def from_url(cls, url: str) -> "RootedFilesystem":
@@ -87,3 +88,10 @@ class RootedFilesystem:
         if not self.root:
             return path.lstrip("/")
         return path.removeprefix(f"{self.root}/").lstrip("/")
+
+    @staticmethod
+    def _normalize_root(root: str) -> str:
+        """Keep filesystem markers, including Windows drive roots, unrooted."""
+        if root in {"", "/"} or re.fullmatch(r"[A-Za-z]:/", root):
+            return ""
+        return root.rstrip("/")

--- a/bakery/filesystem.py
+++ b/bakery/filesystem.py
@@ -82,7 +82,7 @@ class RootedFilesystem:
         relative = normalized.lstrip("/")
         if relative == ".." or relative.startswith("../"):
             raise ValueError("Path escapes the configured filesystem root.")
-        return join_path(self.root, relative)
+        return normalize_path(join_path(self.root, relative))
 
     def _relative(self, path: str) -> str:
         if not self.root:

--- a/bakery/filesystem.py
+++ b/bakery/filesystem.py
@@ -1,0 +1,89 @@
+"""Rooted filesystem support for bakery output."""
+
+import posixpath
+from collections.abc import Iterator
+from os import PathLike
+from typing import BinaryIO, Protocol, cast
+
+from fsspec.core import url_to_fs
+
+
+class _Filesystem(Protocol):
+    def exists(self, path: str) -> bool: ...
+
+    def makedirs(self, path: str, exist_ok: bool) -> None: ...
+
+    def open(self, path: str, mode: str) -> BinaryIO: ...
+
+    def rm(self, path: str, recursive: bool) -> None: ...
+
+    def copy(self, source: str, target: str) -> None: ...
+
+    def find(self, path: str) -> list[str]: ...
+
+
+def normalize_path(path: str | PathLike[str]) -> str:
+    """Return a portable POSIX path without changing its absolute form."""
+    return posixpath.normpath(str(path).replace("\\", "/"))
+
+
+def join_path(*paths: str | PathLike[str]) -> str:
+    """Join filesystem paths with POSIX separators."""
+    return posixpath.join(*(str(path).replace("\\", "/") for path in paths))
+
+
+class RootedFilesystem:
+    """Expose paths relative to a configured fsspec filesystem URL."""
+
+    def __init__(self, filesystem: _Filesystem, root: str = "") -> None:
+        self.filesystem = filesystem
+        self.root = root.rstrip("/")
+
+    @classmethod
+    def from_url(cls, url: str) -> "RootedFilesystem":
+        """Create an adapter for documented legacy Bakery filesystem URLs."""
+        if url.startswith("osfs://"):
+            url = f"file://{url.removeprefix('osfs://')}"
+        elif url.startswith("mem://"):
+            url = f"memory://{url.removeprefix('mem://')}"
+        filesystem, root = url_to_fs(url)
+        return cls(cast("_Filesystem", filesystem), cast("str", root))
+
+    def exists(self, path: str | PathLike[str]) -> bool:
+        return self.filesystem.exists(self._resolve(path))
+
+    def makedirs(self, path: str | PathLike[str]) -> None:
+        self.filesystem.makedirs(self._resolve(path), exist_ok=True)
+
+    def open(self, path: str | PathLike[str], mode: str) -> BinaryIO:
+        return self.filesystem.open(self._resolve(path), mode)
+
+    def removetree(self, path: str | PathLike[str]) -> None:
+        self.filesystem.rm(self._resolve(path), recursive=True)
+
+    def copy(self, source: str | PathLike[str], target: str | PathLike[str]) -> None:
+        self.filesystem.copy(self._resolve(source), self._resolve(target))
+
+    def read_bytes(self, path: str | PathLike[str]) -> bytes:
+        with self.open(path, "rb") as source:
+            return source.read()
+
+    def files(self) -> Iterator[str]:
+        """Yield backend-relative file names below the configured root."""
+        for path in self.filesystem.find(self.root or "/"):
+            yield self._relative(path)
+
+    def _resolve(self, path: str | PathLike[str]) -> str:
+        normalized = normalize_path(path)
+        if not self.root:
+            return normalized
+
+        relative = normalized.lstrip("/")
+        if relative == ".." or relative.startswith("../"):
+            raise ValueError("Path escapes the configured filesystem root.")
+        return join_path(self.root, relative)
+
+    def _relative(self, path: str) -> str:
+        if not self.root:
+            return path.lstrip("/")
+        return path.removeprefix(f"{self.root}/").lstrip("/")

--- a/bakery/management/commands/build.py
+++ b/bakery/management/commands/build.py
@@ -1,10 +1,10 @@
-import contextlib
 import gzip
 import io
 import logging
 import mimetypes
 import multiprocessing
 import os
+import posixpath
 from argparse import ArgumentParser
 from collections.abc import Callable, Mapping
 from multiprocessing.pool import ThreadPool
@@ -17,9 +17,9 @@ from django.core import management
 from django.core.management.base import BaseCommand, CommandError
 from django.urls import get_callable
 from django.utils.encoding import smart_str
-from fs import copy, path
 
 from bakery import DEFAULT_GZIP_CONTENT_TYPES
+from bakery.filesystem import join_path, normalize_path
 
 logger = logging.getLogger(__name__)
 
@@ -124,8 +124,7 @@ Will use settings.BUILD_DIR by default.",
                 raise CommandError(self.build_unconfig_msg)
             self.build_dir = settings.BUILD_DIR
 
-        # Get the datatypes right so fs will be happy
-        self.build_dir = smart_str(self.build_dir)
+        self.build_dir = normalize_path(smart_str(self.build_dir))
         self.static_root = smart_str(settings.STATIC_ROOT)
         self.media_root = smart_str(settings.MEDIA_ROOT)
 
@@ -173,8 +172,7 @@ Will use settings.BUILD_DIR by default.",
         management.call_command("collectstatic", interactive=False, verbosity=0)
 
         # Set the target directory inside the filesystem.
-        target_dir = path.join(self.build_dir, settings.STATIC_URL.lstrip("/"))
-        target_dir = smart_str(target_dir)
+        target_dir = join_path(self.build_dir, settings.STATIC_URL.lstrip("/"))
 
         if Path(self.static_root).exists() and settings.STATIC_URL:
             if getattr(settings, "BAKERY_GZIP", False):
@@ -187,14 +185,14 @@ Will use settings.BUILD_DIR by default.",
                     self.fs_name,
                     target_dir,
                 )
-                copy.copy_dir("osfs:///", self.static_root, self.fs, target_dir)
+                self.copytree(self.static_root, target_dir)
 
         # If they exist in the static directory, copy the robots.txt
         # and favicon.ico files down to the root so they will work
         # on the live website.
-        robots_src = path.join(target_dir, "robots.txt")
+        robots_src = join_path(target_dir, "robots.txt")
         if self.fs.exists(robots_src):
-            robots_target = path.join(self.build_dir, "robots.txt")
+            robots_target = join_path(self.build_dir, "robots.txt")
             logger.debug(
                 "Copying %s%s to %s%s",
                 self.fs_name,
@@ -204,9 +202,9 @@ Will use settings.BUILD_DIR by default.",
             )
             self.fs.copy(robots_src, robots_target)
 
-        favicon_src = path.join(target_dir, "favicon.ico")
+        favicon_src = join_path(target_dir, "favicon.ico")
         if self.fs.exists(favicon_src):
-            favicon_target = path.join(self.build_dir, "favicon.ico")
+            favicon_target = join_path(self.build_dir, "favicon.ico")
             logger.debug(
                 "Copying %s%s to %s%s",
                 self.fs_name,
@@ -224,18 +222,14 @@ Will use settings.BUILD_DIR by default.",
         if self.verbosity > 1:
             self.stdout.write("Building media directory")
         if Path(self.media_root).exists() and settings.MEDIA_URL:
-            target_dir = path.join(
-                self.fs_name, self.build_dir, settings.MEDIA_URL.lstrip("/")
-            )
+            target_dir = join_path(self.build_dir, settings.MEDIA_URL.lstrip("/"))
             logger.debug(
                 "Copying osfs://%s to %s%s",
                 self.media_root,
                 self.fs_name,
                 target_dir,
             )
-            copy.copy_dir(
-                "osfs:///", smart_str(self.media_root), self.fs, smart_str(target_dir)
-            )
+            self.copytree(self.media_root, target_dir)
 
     def get_view_instance(self, view: Callable[[], BuildableView]) -> BuildableView:
         """
@@ -269,7 +263,7 @@ Will use settings.BUILD_DIR by default.",
                 # Figure out what is going where
                 source_path = str(Path(dirpath) / f)
                 rel_path = os.path.relpath(dirpath, source_dir)
-                target_path = str(Path(target_dir) / rel_path / f)
+                target_path = join_path(target_dir, rel_path, f)
                 # Add it to our list to build
                 build_list.append((source_path, target_path))
 
@@ -300,10 +294,9 @@ Will use settings.BUILD_DIR by default.",
         Gzips JavaScript, CSS and HTML and other files along the way.
         """
         # And then where we want to copy it to.
-        target_dir = path.dirname(target_path)
+        target_dir = posixpath.dirname(target_path)
         if not self.fs.exists(target_dir):
-            with contextlib.suppress(OSError):
-                self.fs.makedirs(target_dir)
+            self.fs.makedirs(target_dir)
 
         # determine the mimetype of the file
         guess = mimetypes.guess_type(source_path)
@@ -319,9 +312,7 @@ Will use settings.BUILD_DIR by default.",
                 self.fs_name,
                 target_path,
             )
-            copy.copy_file(
-                "osfs:///", smart_str(source_path), self.fs, smart_str(target_path)
-            )
+            self.copyfile(source_path, target_path)
 
         # # if the file is already gzipped
         elif encoding == "gzip":
@@ -331,9 +322,7 @@ Will use settings.BUILD_DIR by default.",
                 self.fs_name,
                 target_path,
             )
-            copy.copy_file(
-                "osfs:///", smart_str(source_path), self.fs, smart_str(target_path)
-            )
+            self.copyfile(source_path, target_path)
 
         # If it is one we want to gzip...
         else:
@@ -349,7 +338,7 @@ Will use settings.BUILD_DIR by default.",
                 # Write GZIP data to an in-memory buffer
                 data_buffer = io.BytesIO()
                 with gzip.GzipFile(
-                    filename=path.basename(target_path),
+                    filename=posixpath.basename(target_path),
                     mode="wb",
                     fileobj=data_buffer,
                     mtime=0,
@@ -359,3 +348,22 @@ Will use settings.BUILD_DIR by default.",
                 # Write that buffer out to the filesystem
                 with self.fs.open(smart_str(target_path), "wb") as outfile:
                     outfile.write(data_buffer.getvalue())
+
+    def copytree(self, source_dir: str, target_dir: str) -> None:
+        """Copy a local directory into the configured output backend."""
+        for dirpath, _dirnames, filenames in os.walk(source_dir):
+            for filename in filenames:
+                source_path = str(Path(dirpath) / filename)
+                relative_path = os.path.relpath(source_path, source_dir)
+                self.copyfile(source_path, join_path(target_dir, relative_path))
+
+    def copyfile(self, source_path: str, target_path: str) -> None:
+        """Copy one local file into the configured output backend."""
+        target_dir = posixpath.dirname(target_path)
+        if target_dir and not self.fs.exists(target_dir):
+            self.fs.makedirs(target_dir)
+        with (
+            Path(source_path).open("rb") as source,
+            self.fs.open(target_path, "wb") as target,
+        ):
+            target.write(source.read())

--- a/bakery/management/commands/build.py
+++ b/bakery/management/commands/build.py
@@ -20,7 +20,7 @@ from django.urls import get_callable
 from django.utils.encoding import smart_str
 
 from bakery import DEFAULT_GZIP_CONTENT_TYPES
-from bakery.filesystem import join_path, normalize_path
+from bakery.filesystem import RootedFilesystem, join_path, normalize_path
 
 logger = logging.getLogger(__name__)
 
@@ -133,6 +133,12 @@ Will use settings.BUILD_DIR by default.",
         self.app = apps.get_app_config("bakery")
         self.fs = self.app.filesystem
         self.fs_name = self.app.filesystem_name
+        if (
+            self.build_dir == "."
+            and isinstance(self.fs, RootedFilesystem)
+            and not self.fs.root
+        ):
+            raise CommandError("BUILD_DIR must not target an unrooted filesystem root.")
 
         # If the build dir doesn't exist make it
         if not self.fs.exists(self.build_dir):

--- a/bakery/management/commands/build.py
+++ b/bakery/management/commands/build.py
@@ -5,6 +5,7 @@ import mimetypes
 import multiprocessing
 import os
 import posixpath
+import shutil
 from argparse import ArgumentParser
 from collections.abc import Callable, Mapping
 from multiprocessing.pool import ThreadPool
@@ -312,7 +313,7 @@ Will use settings.BUILD_DIR by default.",
                 self.fs_name,
                 target_path,
             )
-            self.copyfile(source_path, target_path)
+            self.copy_local_file(source_path, target_path)
 
         # # if the file is already gzipped
         elif encoding == "gzip":
@@ -322,7 +323,7 @@ Will use settings.BUILD_DIR by default.",
                 self.fs_name,
                 target_path,
             )
-            self.copyfile(source_path, target_path)
+            self.copy_local_file(source_path, target_path)
 
         # If it is one we want to gzip...
         else:
@@ -355,9 +356,9 @@ Will use settings.BUILD_DIR by default.",
             for filename in filenames:
                 source_path = str(Path(dirpath) / filename)
                 relative_path = os.path.relpath(source_path, source_dir)
-                self.copyfile(source_path, join_path(target_dir, relative_path))
+                self.copy_local_file(source_path, join_path(target_dir, relative_path))
 
-    def copyfile(self, source_path: str, target_path: str) -> None:
+    def copy_local_file(self, source_path: str, target_path: str) -> None:
         """Copy one local file into the configured output backend."""
         target_dir = posixpath.dirname(target_path)
         if target_dir and not self.fs.exists(target_dir):
@@ -366,4 +367,4 @@ Will use settings.BUILD_DIR by default.",
             Path(source_path).open("rb") as source,
             self.fs.open(target_path, "wb") as target,
         ):
-            target.write(source.read())
+            shutil.copyfileobj(source, target)

--- a/bakery/management/commands/unbuild.py
+++ b/bakery/management/commands/unbuild.py
@@ -1,14 +1,16 @@
-import shutil
-from pathlib import Path
-
+from django.apps import apps
 from django.conf import settings
 from django.core.management.base import BaseCommand
+
+from bakery.filesystem import normalize_path
 
 
 class Command(BaseCommand):
     help = "Empties the build directory"
 
     def handle(self, *args: object, **kwds: object) -> object:
-        if Path(settings.BUILD_DIR).exists():
+        filesystem = apps.get_app_config("bakery").filesystem
+        build_dir = normalize_path(settings.BUILD_DIR)
+        if filesystem.exists(build_dir):
             self.stdout.write("Clearing the build directory\n")
-            shutil.rmtree(settings.BUILD_DIR)
+            filesystem.removetree(build_dir)

--- a/bakery/management/commands/unbuild.py
+++ b/bakery/management/commands/unbuild.py
@@ -1,8 +1,8 @@
 from django.apps import apps
 from django.conf import settings
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 
-from bakery.filesystem import normalize_path
+from bakery.filesystem import RootedFilesystem, normalize_path
 
 
 class Command(BaseCommand):
@@ -11,6 +11,12 @@ class Command(BaseCommand):
     def handle(self, *args: object, **kwds: object) -> object:
         filesystem = apps.get_app_config("bakery").filesystem
         build_dir = normalize_path(settings.BUILD_DIR)
+        if (
+            build_dir == "."
+            and isinstance(filesystem, RootedFilesystem)
+            and not filesystem.root
+        ):
+            raise CommandError("BUILD_DIR must not target an unrooted filesystem root.")
         if filesystem.exists(build_dir):
             self.stdout.write("Clearing the build directory\n")
             filesystem.removetree(build_dir)

--- a/bakery/tests/test_filesystem_contract.py
+++ b/bakery/tests/test_filesystem_contract.py
@@ -305,6 +305,38 @@ def test_empty_build_directory_stays_within_selected_backend_root(
     assert not filesystem.filesystem.exists("/index.html")
 
 
+@pytest.mark.parametrize("build_dir", ["", "."])
+@pytest.mark.parametrize("backend", ["local", "memory"])
+def test_build_and_unbuild_clear_a_rooted_empty_build_directory(
+    settings, tmp_path: Path, build_dir: str, backend: str
+) -> None:
+    if backend == "local":
+        root = tmp_path / f"{build_dir or 'empty'}-root"
+        root.mkdir()
+        filesystem_name = f"osfs://{root}"
+    else:
+        root = Path(f"/{build_dir or 'empty'}-root")
+        filesystem_name = f"mem://{root.name}"
+    filesystem = RootedFilesystem.from_url(filesystem_name)
+    settings.BUILD_DIR = build_dir
+    settings.BAKERY_FILESYSTEM = filesystem_name
+    settings.BAKERY_VIEWS = (
+        "bakery.tests.test_filesystem_contract.FilesystemContractView",
+    )
+
+    with configured_filesystem(filesystem, filesystem_name):
+        call_command("build", skip_static=True, skip_media=True)
+        with filesystem.open("stale.txt", "wb") as stale_file:
+            stale_file.write(b"stale")
+        call_command("build", skip_static=True, skip_media=True)
+        output = filesystem_snapshot(filesystem)
+        call_command("unbuild")
+
+    assert "stale.txt" not in output
+    assert set(output) == {"pages/index.html"}
+    assert not filesystem.filesystem.exists(str(root))
+
+
 @pytest.mark.parametrize("build_dir", ["site", "", "."])
 def test_build_paths_cannot_escape_the_configured_build_prefix(
     settings, build_dir: str

--- a/bakery/tests/test_filesystem_contract.py
+++ b/bakery/tests/test_filesystem_contract.py
@@ -1,6 +1,7 @@
 """Behavioral contract for the filesystem adapter used by bakery builds."""
 
 import gzip
+import io
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -11,7 +12,8 @@ import pytest
 from django.apps import apps
 from django.core.management import call_command
 
-from bakery.filesystem import RootedFilesystem
+from bakery.filesystem import RootedFilesystem, _Filesystem
+from bakery.management.commands.build import Command
 from bakery.views import BuildableTemplateView
 from bakery.views.base import BuildableMixin
 
@@ -238,6 +240,36 @@ def test_backend_write_failures_are_propagated(settings) -> None:
             view.build()
 
 
+class HistoricalPrepDirectoryView(BuildableTemplateView):
+    """A view that uses the long-standing relative prep_directory contract."""
+
+    build_path = "historical/nested/index.html"
+    template_name = "templateview.html"
+    prep_paths: list[str]
+
+    def prep_directory(self, target_dir: str) -> None:
+        self.prep_paths.append(target_dir)
+        super().prep_directory(target_dir)
+
+
+def test_prep_directory_accepts_build_relative_paths_with_a_rooted_backend(
+    settings,
+) -> None:
+    filesystem = RootedFilesystem.from_url("mem://historical-prep")
+    settings.BUILD_DIR = "site"
+    view = HistoricalPrepDirectoryView()
+    view.prep_paths = []
+
+    with configured_filesystem(filesystem, "mem://historical-prep"):
+        view.build()
+        output = filesystem_snapshot(filesystem)
+
+    assert view.prep_paths == ["historical/nested/index.html"]
+    assert set(output) == {"site/historical/nested/index.html"}
+    assert filesystem.filesystem.exists("/historical-prep/site/historical/nested")
+    assert not filesystem.filesystem.exists("/site/historical/nested")
+
+
 def test_windows_style_build_paths_are_normalized_without_platform_assumptions(
     settings,
 ) -> None:
@@ -254,9 +286,31 @@ def test_windows_style_build_paths_are_normalized_without_platform_assumptions(
     assert set(output) == {"site/windows/nested/index.html"}
 
 
-def test_build_paths_cannot_escape_the_configured_build_prefix(settings) -> None:
+@pytest.mark.parametrize("build_dir", ["", "."])
+def test_empty_build_directory_stays_within_selected_backend_root(
+    settings, build_dir: str
+) -> None:
+    filesystem = RootedFilesystem.from_url("mem://empty-build-dir")
+    settings.BUILD_DIR = build_dir
+
+    with configured_filesystem(filesystem, "mem://empty-build-dir"):
+        BuildableTemplateView(
+            build_path="index.html",
+            template_name="templateview.html",
+        ).build()
+        output = filesystem_snapshot(filesystem)
+
+    assert set(output) == {"index.html"}
+    assert filesystem.filesystem.exists("/empty-build-dir/index.html")
+    assert not filesystem.filesystem.exists("/index.html")
+
+
+@pytest.mark.parametrize("build_dir", ["site", "", "."])
+def test_build_paths_cannot_escape_the_configured_build_prefix(
+    settings, build_dir: str
+) -> None:
     filesystem = RootedFilesystem.from_url("mem://escape")
-    settings.BUILD_DIR = "site"
+    settings.BUILD_DIR = build_dir
 
     with configured_filesystem(filesystem, "mem://escape"):
         with pytest.raises(ValueError, match="BUILD_DIR"):
@@ -267,6 +321,61 @@ def test_build_paths_cannot_escape_the_configured_build_prefix(settings) -> None
         output = filesystem_snapshot(filesystem)
 
     assert set(output) == set()
+
+
+class ChunkedSource(io.BytesIO):
+    """A source stream that rejects reads without a bounded size."""
+
+    def read(self, size: int = -1) -> bytes:
+        if size < 0:
+            raise AssertionError("copy_local_file must use bounded reads")
+        return super().read(size)
+
+
+def test_copy_local_file_streams_source_in_chunks(monkeypatch) -> None:
+    filesystem = RootedFilesystem.from_url("mem://streaming-copy")
+    source = ChunkedSource(b"large enough to require more than one chunk")
+    expected = source.getvalue()
+    command = Command()
+    command.fs = filesystem
+
+    monkeypatch.setattr(Path, "open", lambda *_args, **_kwargs: source)
+
+    command.copy_local_file("source.bin", "assets/source.bin")
+
+    assert filesystem.read_bytes("assets/source.bin") == expected
+
+
+class RecordingFilesystem:
+    """A minimal fsspec-like backend for URL-root parsing tests."""
+
+    def exists(self, _path: str) -> bool:
+        return False
+
+    def makedirs(self, _path: str, exist_ok: bool) -> None:
+        assert exist_ok
+
+    def open(self, _path: str, _mode: str) -> BinaryIO:
+        raise AssertionError("This test only resolves paths")
+
+    def rm(self, _path: str, recursive: bool) -> None:
+        assert recursive
+
+    def copy(self, _source: str, _target: str) -> None:
+        raise AssertionError("This test only resolves paths")
+
+    def find(self, _path: str) -> list[str]:
+        return []
+
+
+def test_windows_drive_root_from_url_is_unrooted(monkeypatch) -> None:
+    backend: _Filesystem = RecordingFilesystem()
+    monkeypatch.setattr("bakery.filesystem.url_to_fs", lambda _url: (backend, "C:/"))
+
+    filesystem = RootedFilesystem.from_url("osfs:///")
+
+    assert filesystem.root == ""
+    assert filesystem._resolve("C:/site/index.html") == "C:/site/index.html"
 
 
 @pytest.mark.parametrize(

--- a/bakery/tests/test_filesystem_contract.py
+++ b/bakery/tests/test_filesystem_contract.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 import pytest
 from django.apps import apps
 from django.core.management import call_command
+from django.core.management.base import CommandError
 
 from bakery.filesystem import RootedFilesystem, _Filesystem
 from bakery.management.commands.build import Command
@@ -355,6 +356,39 @@ def test_build_paths_cannot_escape_the_configured_build_prefix(
     assert set(output) == set()
 
 
+def test_windows_drive_build_paths_cannot_escape_the_configured_build_prefix(
+    settings,
+) -> None:
+    filesystem = RootedFilesystem.from_url("mem://drive-path")
+    settings.BUILD_DIR = "."
+
+    with configured_filesystem(filesystem, "mem://drive-path"):
+        with pytest.raises(ValueError, match="BUILD_DIR"):
+            BuildableTemplateView(
+                build_path="C:/outside/index.html",
+                template_name="templateview.html",
+            ).build()
+
+    assert filesystem_snapshot(filesystem) == {}
+
+
+@pytest.mark.parametrize("build_dir", ["", "."])
+def test_commands_reject_an_unrooted_local_build_directory(
+    settings, build_dir: str
+) -> None:
+    filesystem = RootedFilesystem.from_url("osfs:///")
+    settings.BUILD_DIR = build_dir
+    settings.BAKERY_VIEWS = (
+        "bakery.tests.test_filesystem_contract.FilesystemContractView",
+    )
+
+    with configured_filesystem(filesystem, "osfs:///"):
+        with pytest.raises(CommandError, match="unrooted filesystem root"):
+            call_command("build", skip_static=True, skip_media=True)
+        with pytest.raises(CommandError, match="unrooted filesystem root"):
+            call_command("unbuild")
+
+
 class ChunkedSource(io.BytesIO):
     """A source stream that rejects reads without a bounded size."""
 
@@ -408,6 +442,12 @@ def test_windows_drive_root_from_url_is_unrooted(monkeypatch) -> None:
 
     assert filesystem.root == ""
     assert filesystem._resolve("C:/site/index.html") == "C:/site/index.html"
+
+
+@pytest.mark.parametrize("url", ["s3://bucket", "ftp://example.com/output"])
+def test_undocumented_filesystem_urls_are_rejected(url: str) -> None:
+    with pytest.raises(ValueError, match="BAKERY_FILESYSTEM"):
+        RootedFilesystem.from_url(url)
 
 
 @pytest.mark.parametrize(

--- a/bakery/tests/test_filesystem_contract.py
+++ b/bakery/tests/test_filesystem_contract.py
@@ -4,14 +4,14 @@ import gzip
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import BinaryIO
+from typing import BinaryIO, Protocol
 from unittest.mock import patch
 
-import fs
 import pytest
 from django.apps import apps
 from django.core.management import call_command
 
+from bakery.filesystem import RootedFilesystem
 from bakery.views import BuildableTemplateView
 from bakery.views.base import BuildableMixin
 
@@ -21,8 +21,20 @@ class FilesystemContractView(BuildableTemplateView):
     template_name = "templateview.html"
 
 
+class WritableFilesystem(Protocol):
+    """The operations buildable views use from an output backend."""
+
+    def exists(self, path: str) -> bool: ...
+
+    def makedirs(self, path: str) -> None: ...
+
+    def open(self, path: str, mode: str) -> BinaryIO: ...
+
+    def removetree(self, path: str) -> None: ...
+
+
 @contextmanager
-def configured_filesystem(filesystem: fs.base.FS, name: str) -> Iterator[None]:
+def configured_filesystem(filesystem: WritableFilesystem, name: str) -> Iterator[None]:
     """Connect a filesystem to the command and buildable views for one build."""
     app = apps.get_app_config("bakery")
     with (
@@ -34,17 +46,16 @@ def configured_filesystem(filesystem: fs.base.FS, name: str) -> Iterator[None]:
         yield
 
 
-def filesystem_snapshot(filesystem: fs.base.FS) -> dict[str, bytes]:
+def filesystem_snapshot(filesystem: RootedFilesystem) -> dict[str, bytes]:
     """Return backend-relative output paths and their exact bytes."""
     return {
-        file_path.lstrip("/"): filesystem.readbytes(file_path)
-        for file_path in filesystem.walk.files()
+        file_path: filesystem.read_bytes(file_path) for file_path in filesystem.files()
     }
 
 
 def build_snapshot(
     settings,
-    filesystem: fs.base.FS,
+    filesystem: RootedFilesystem,
     filesystem_name: str,
     *,
     gzip_enabled: bool = False,
@@ -100,12 +111,8 @@ def test_rooted_local_backend_keeps_output_within_selected_root(
     local_root = tmp_path / "local-root"
     local_root.mkdir()
     local_name = f"osfs://{local_root}"
-    filesystem = fs.open_fs(local_name)
-
-    try:
-        output = build_snapshot(settings, filesystem, local_name, gzip_enabled=True)
-    finally:
-        filesystem.close()
+    filesystem = RootedFilesystem.from_url(local_name)
+    output = build_snapshot(settings, filesystem, local_name, gzip_enabled=True)
 
     assert_expected_snapshot(output)
     assert {
@@ -117,68 +124,46 @@ def test_rooted_local_backend_keeps_output_within_selected_root(
 
 
 def test_rooted_memory_backend_keeps_output_within_selected_root(settings) -> None:
-    parent = fs.open_fs("mem://")
-    parent.makedirs("selected-root")
-    filesystem = parent.opendir("selected-root")
-
-    try:
-        output = build_snapshot(settings, filesystem, "mem://", gzip_enabled=True)
-    finally:
-        filesystem.close()
+    filesystem = RootedFilesystem.from_url("mem://selected-root")
+    output = build_snapshot(
+        settings, filesystem, "mem://selected-root", gzip_enabled=True
+    )
 
     assert_expected_snapshot(output)
-    assert all(parent.exists(f"selected-root/{file_path}") for file_path in output)
-    assert not parent.exists("site/pages/index.html")
-    parent.close()
+    assert all(
+        filesystem.filesystem.exists(f"/selected-root/{file_path}")
+        for file_path in output
+    )
+    assert not filesystem.filesystem.exists("/site/pages/index.html")
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Media copying currently includes the BAKERY_FILESYSTEM URL in the "
-        "destination path, so rooted local and memory backend paths differ."
-    ),
-)
 def test_local_and_memory_backends_use_equivalent_media_paths(
     settings, tmp_path: Path
 ) -> None:
     local_root = tmp_path / "local-root"
     local_root.mkdir()
     local_name = f"osfs://{local_root}"
-    local_filesystem = fs.open_fs(local_name)
-    memory_parent = fs.open_fs("mem://")
-    memory_parent.makedirs("memory-root")
-    memory_filesystem = memory_parent.opendir("memory-root")
+    local_filesystem = RootedFilesystem.from_url(local_name)
+    memory_filesystem = RootedFilesystem.from_url("mem://memory-root")
+    local_output = build_snapshot(
+        settings, local_filesystem, local_name, gzip_enabled=True
+    )
+    memory_output = build_snapshot(
+        settings, memory_filesystem, "mem://memory-root", gzip_enabled=True
+    )
 
-    try:
-        local_output = build_snapshot(
-            settings, local_filesystem, local_name, gzip_enabled=True
-        )
-        memory_output = build_snapshot(
-            settings, memory_filesystem, "mem://", gzip_enabled=True
-        )
-    finally:
-        local_filesystem.close()
-        memory_filesystem.close()
-        memory_parent.close()
-
-    assert media_output_path(local_output) == media_output_path(memory_output)
+    assert local_output == memory_output
 
 
 def test_pooled_and_non_pooled_gzip_builds_produce_identical_output(settings) -> None:
-    non_pooled = fs.open_fs("mem://")
-    pooled = fs.open_fs("mem://")
-
-    try:
-        non_pooled_output = build_snapshot(
-            settings, non_pooled, "mem://", gzip_enabled=True
-        )
-        pooled_output = build_snapshot(
-            settings, pooled, "mem://", gzip_enabled=True, pooling=True
-        )
-    finally:
-        non_pooled.close()
-        pooled.close()
+    non_pooled = RootedFilesystem.from_url("mem://non-pooled")
+    pooled = RootedFilesystem.from_url("mem://pooled")
+    non_pooled_output = build_snapshot(
+        settings, non_pooled, "mem://non-pooled", gzip_enabled=True
+    )
+    pooled_output = build_snapshot(
+        settings, pooled, "mem://pooled", gzip_enabled=True, pooling=True
+    )
 
     assert_expected_snapshot(non_pooled_output)
     assert_expected_snapshot(pooled_output)
@@ -187,21 +172,17 @@ def test_pooled_and_non_pooled_gzip_builds_produce_identical_output(settings) ->
 
 def test_unbuild_removes_a_local_build_directory(settings, tmp_path: Path) -> None:
     build_directory = tmp_path / "build"
-    filesystem = fs.open_fs("osfs:///")
+    filesystem = RootedFilesystem.from_url("osfs:///")
     settings.BUILD_DIR = str(build_directory)
     settings.BAKERY_FILESYSTEM = "osfs:///"
     settings.BAKERY_VIEWS = (
         "bakery.tests.test_filesystem_contract.FilesystemContractView",
     )
 
-    try:
-        with configured_filesystem(filesystem, "osfs:///"):
-            call_command("build")
+    with configured_filesystem(filesystem, "osfs:///"):
+        call_command("build")
         assert (build_directory / "pages" / "index.html").exists()
-
         call_command("unbuild")
-    finally:
-        filesystem.close()
 
     assert not build_directory.exists()
 
@@ -209,22 +190,19 @@ def test_unbuild_removes_a_local_build_directory(settings, tmp_path: Path) -> No
 def test_absolute_and_relative_posix_build_paths_share_the_build_prefix(
     settings,
 ) -> None:
-    filesystem = fs.open_fs("mem://")
+    filesystem = RootedFilesystem.from_url("mem://absolute-and-relative")
     settings.BUILD_DIR = "site"
 
-    try:
-        with configured_filesystem(filesystem, "mem://"):
-            BuildableTemplateView(
-                build_path="/absolute/index.html",
-                template_name="templateview.html",
-            ).build()
-            BuildableTemplateView(
-                build_path="relative/index.html",
-                template_name="templateview.html",
-            ).build()
-    finally:
+    with configured_filesystem(filesystem, "mem://absolute-and-relative"):
+        BuildableTemplateView(
+            build_path="/absolute/index.html",
+            template_name="templateview.html",
+        ).build()
+        BuildableTemplateView(
+            build_path="relative/index.html",
+            template_name="templateview.html",
+        ).build()
         output = filesystem_snapshot(filesystem)
-        filesystem.close()
 
     assert set(output) == {
         "site/absolute/index.html",
@@ -260,52 +238,49 @@ def test_backend_write_failures_are_propagated(settings) -> None:
             view.build()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Windows-style separators are currently passed to the backend as literal "
-        "characters instead of normalized POSIX output paths (issue #158)."
-    ),
-)
 def test_windows_style_build_paths_are_normalized_without_platform_assumptions(
     settings,
 ) -> None:
-    filesystem = fs.open_fs("mem://")
+    filesystem = RootedFilesystem.from_url("mem://windows-style")
     settings.BUILD_DIR = "site"
 
-    try:
-        with configured_filesystem(filesystem, "mem://"):
-            BuildableTemplateView(
-                build_path=r"windows\nested\index.html",
-                template_name="templateview.html",
-            ).build()
+    with configured_filesystem(filesystem, "mem://windows-style"):
+        BuildableTemplateView(
+            build_path=r"windows\nested\index.html",
+            template_name="templateview.html",
+        ).build()
         output = filesystem_snapshot(filesystem)
-    finally:
-        filesystem.close()
 
     assert set(output) == {"site/windows/nested/index.html"}
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Relative back-references can currently escape the configured BUILD_DIR "
-        "prefix instead of raising ValueError before writing."
-    ),
-)
 def test_build_paths_cannot_escape_the_configured_build_prefix(settings) -> None:
-    filesystem = fs.open_fs("mem://")
+    filesystem = RootedFilesystem.from_url("mem://escape")
     settings.BUILD_DIR = "site"
 
-    try:
-        with configured_filesystem(filesystem, "mem://"):
-            with pytest.raises(ValueError, match="BUILD_DIR"):
-                BuildableTemplateView(
-                    build_path="../outside.html",
-                    template_name="templateview.html",
-                ).build()
+    with configured_filesystem(filesystem, "mem://escape"):
+        with pytest.raises(ValueError, match="BUILD_DIR"):
+            BuildableTemplateView(
+                build_path="../outside.html",
+                template_name="templateview.html",
+            ).build()
         output = filesystem_snapshot(filesystem)
-    finally:
-        filesystem.close()
 
     assert set(output) == set()
+
+
+@pytest.mark.parametrize(
+    ("url", "expected_root"),
+    [
+        ("osfs:///", ""),
+        ("osfs:///tmp/bakery-output", "/tmp/bakery-output"),
+        ("mem://", ""),
+        ("mem://bakery-output", "/bakery-output"),
+    ],
+)
+def test_documented_filesystem_urls_use_expected_roots(
+    url: str, expected_root: str
+) -> None:
+    filesystem = RootedFilesystem.from_url(url)
+
+    assert filesystem.root == expected_root

--- a/bakery/views/base.py
+++ b/bakery/views/base.py
@@ -7,9 +7,9 @@ import gzip
 import io
 import logging
 import mimetypes
+import posixpath
 from collections.abc import Callable
 from os import PathLike
-from pathlib import Path
 from typing import BinaryIO, Protocol, cast
 
 from django.apps import apps
@@ -19,9 +19,9 @@ from django.test.client import RequestFactory
 from django.urls import NoReverseMatch, reverse
 from django.utils.encoding import smart_str
 from django.views.generic import RedirectView, TemplateView
-from fs import path
 
 from bakery import DEFAULT_GZIP_CONTENT_TYPES
+from bakery.filesystem import join_path, normalize_path
 from bakery.management.commands import get_s3_client
 
 logger = logging.getLogger(__name__)
@@ -94,12 +94,22 @@ class BuildableMixin:
         """
         Prepares a new directory to store the file at the provided path, if needed.
         """
-        dirname = path.dirname(str(target_dir))
-        if dirname:
-            dirname = path.join(str(cast("BuildPath", settings.BUILD_DIR)), dirname)
-            if not self.fs.exists(dirname):
-                logger.debug("Creating directory at %s%s", self.fs_name, dirname)
-                self.fs.makedirs(dirname)
+        dirname = posixpath.dirname(normalize_path(target_dir))
+        if dirname and not self.fs.exists(dirname):
+            logger.debug("Creating directory at %s%s", self.fs_name, dirname)
+            self.fs.makedirs(dirname)
+
+    def get_output_path(self, build_path: BuildPath) -> str:
+        """Return a normalized path contained by the configured build directory."""
+        build_dir = normalize_path(cast("BuildPath", settings.BUILD_DIR))
+        output_path = normalize_path(
+            join_path(build_dir, normalize_path(build_path).lstrip("/"))
+        )
+        if output_path != build_dir and not output_path.startswith(
+            f"{build_dir.rstrip('/')}/"
+        ):
+            raise ValueError("Build path must remain within BUILD_DIR.")
+        return output_path
 
     def build_file(self, target_path: BuildPath, html: bytes) -> None:
         if self.is_gzippable(target_path):
@@ -143,7 +153,7 @@ class BuildableMixin:
         # Write GZIP data to an in-memory buffer
         data_buffer = io.BytesIO()
         with gzip.GzipFile(
-            filename=path.basename(str(target_path)),
+            filename=posixpath.basename(str(target_path)),
             mode="wb",
             fileobj=data_buffer,
             mtime=0,
@@ -180,12 +190,12 @@ class BuildableTemplateView(TemplateView, BuildableMixin):
         logger.debug("Building %s", self.template_name)
         build_path = self.get_build_path()
         self.request = self.create_request(build_path)
-        path = str(Path(cast("BuildPath", settings.BUILD_DIR)) / build_path)
-        self.prep_directory(build_path)
-        self.build_file(path, self.get_content())
+        output_path = self.get_output_path(build_path)
+        self.prep_directory(output_path)
+        self.build_file(output_path, self.get_content())
 
     def get_build_path(self) -> str:
-        return str(self.build_path).lstrip("/")
+        return normalize_path(self.build_path).lstrip("/")
 
 
 class Buildable404View(BuildableTemplateView):
@@ -237,11 +247,11 @@ class BuildableRedirectView(RedirectView, BuildableMixin):
         logger.debug(
             "Building redirect from %s to %s", self.build_path, self.get_redirect_url()
         )
-        build_path = str(self.build_path)
+        build_path = normalize_path(self.build_path).lstrip("/")
         self.request = self.create_request(build_path)
-        path = str(Path(cast("BuildPath", settings.BUILD_DIR)) / build_path)
-        self.prep_directory(build_path)
-        self.build_file(path, self.get_content())
+        output_path = self.get_output_path(build_path)
+        self.prep_directory(output_path)
+        self.build_file(output_path, self.get_content())
 
     def get_redirect_url(self, *args: object, **kwargs: object) -> str | None:
         """

--- a/bakery/views/base.py
+++ b/bakery/views/base.py
@@ -8,6 +8,7 @@ import io
 import logging
 import mimetypes
 import posixpath
+import re
 from collections.abc import Callable
 from os import PathLike
 from typing import BinaryIO, Protocol, cast
@@ -21,7 +22,7 @@ from django.utils.encoding import smart_str
 from django.views.generic import RedirectView, TemplateView
 
 from bakery import DEFAULT_GZIP_CONTENT_TYPES
-from bakery.filesystem import join_path, normalize_path
+from bakery.filesystem import RootedFilesystem, join_path, normalize_path
 from bakery.management.commands import get_s3_client
 
 logger = logging.getLogger(__name__)
@@ -106,10 +107,17 @@ class BuildableMixin:
     def get_output_path(self, build_path: BuildPath) -> str:
         """Return a normalized path contained by the configured build directory."""
         build_dir = normalize_path(cast("BuildPath", settings.BUILD_DIR))
-        relative_path = normalize_path(build_path).lstrip("/")
+        normalized_path = normalize_path(build_path)
+        if re.fullmatch(r"[A-Za-z]:/.*", normalized_path):
+            raise ValueError("Build path must remain within BUILD_DIR.")
+        relative_path = normalized_path.lstrip("/")
         if relative_path == ".." or relative_path.startswith("../"):
             raise ValueError("Build path must remain within BUILD_DIR.")
         if build_dir in {"", "."}:
+            if isinstance(self.fs, RootedFilesystem) and not self.fs.root:
+                raise ValueError(
+                    "BUILD_DIR must not target an unrooted filesystem root."
+                )
             return relative_path
         return join_path(build_dir, relative_path)
 

--- a/bakery/views/base.py
+++ b/bakery/views/base.py
@@ -92,9 +92,13 @@ class BuildableMixin:
 
     def prep_directory(self, target_dir: BuildPath) -> None:
         """
-        Prepares a new directory to store the file at the provided path, if needed.
+        Prepares the parent directory for a BUILD_DIR-relative output path.
         """
-        dirname = posixpath.dirname(normalize_path(target_dir))
+        self._prep_output_directory(self.get_output_path(target_dir))
+
+    def _prep_output_directory(self, output_path: str) -> None:
+        """Prepare the parent directory for an already resolved output path."""
+        dirname = posixpath.dirname(output_path)
         if dirname and not self.fs.exists(dirname):
             logger.debug("Creating directory at %s%s", self.fs_name, dirname)
             self.fs.makedirs(dirname)
@@ -102,14 +106,12 @@ class BuildableMixin:
     def get_output_path(self, build_path: BuildPath) -> str:
         """Return a normalized path contained by the configured build directory."""
         build_dir = normalize_path(cast("BuildPath", settings.BUILD_DIR))
-        output_path = normalize_path(
-            join_path(build_dir, normalize_path(build_path).lstrip("/"))
-        )
-        if output_path != build_dir and not output_path.startswith(
-            f"{build_dir.rstrip('/')}/"
-        ):
+        relative_path = normalize_path(build_path).lstrip("/")
+        if relative_path == ".." or relative_path.startswith("../"):
             raise ValueError("Build path must remain within BUILD_DIR.")
-        return output_path
+        if build_dir in {"", "."}:
+            return relative_path
+        return join_path(build_dir, relative_path)
 
     def build_file(self, target_path: BuildPath, html: bytes) -> None:
         if self.is_gzippable(target_path):
@@ -191,7 +193,7 @@ class BuildableTemplateView(TemplateView, BuildableMixin):
         build_path = self.get_build_path()
         self.request = self.create_request(build_path)
         output_path = self.get_output_path(build_path)
-        self.prep_directory(output_path)
+        self.prep_directory(build_path)
         self.build_file(output_path, self.get_content())
 
     def get_build_path(self) -> str:
@@ -250,7 +252,7 @@ class BuildableRedirectView(RedirectView, BuildableMixin):
         build_path = normalize_path(self.build_path).lstrip("/")
         self.request = self.create_request(build_path)
         output_path = self.get_output_path(build_path)
-        self.prep_directory(output_path)
+        self.prep_directory(build_path)
         self.build_file(output_path, self.get_content())
 
     def get_redirect_url(self, *args: object, **kwargs: object) -> str | None:

--- a/bakery/views/dates.py
+++ b/bakery/views/dates.py
@@ -56,7 +56,7 @@ class BuildableArchiveIndexView(ArchiveIndexView, BuildableMixin):
         logger.debug("Building %s", self.build_path)
         self.request = self.create_request(self.build_path)
         target_path = self.get_output_path(self.build_path)
-        self.prep_directory(target_path)
+        self.prep_directory(self.build_path)
         self.build_file(target_path, self.get_content())
 
 
@@ -105,7 +105,7 @@ class BuildableYearArchiveView(YearArchiveView, BuildableMixin):
         target_path = self.get_output_path(
             join_path(self.get_url().lstrip("/"), "index.html")
         )
-        self.prep_directory(target_path)
+        self._prep_output_directory(target_path)
         return target_path
 
     def build_year(self, dt: date) -> None:
@@ -193,7 +193,7 @@ class BuildableMonthArchiveView(MonthArchiveView, BuildableMixin):
         target_path = self.get_output_path(
             join_path(self.get_url().lstrip("/"), "index.html")
         )
-        self.prep_directory(target_path)
+        self._prep_output_directory(target_path)
         return target_path
 
     def build_month(self, dt: date) -> None:
@@ -299,7 +299,7 @@ class BuildableDayArchiveView(DayArchiveView, BuildableMixin):
         target_path = self.get_output_path(
             join_path(self.get_url().lstrip("/"), "index.html")
         )
-        self.prep_directory(target_path)
+        self._prep_output_directory(target_path)
         return target_path
 
     def build_day(self, dt: date) -> None:

--- a/bakery/views/dates.py
+++ b/bakery/views/dates.py
@@ -4,23 +4,20 @@ for building flat files.
 """
 
 import logging
+import posixpath
 from collections.abc import Callable
 from datetime import date
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
-if TYPE_CHECKING:
-    from os import PathLike
-
-from django.conf import settings
 from django.views.generic.dates import (
     ArchiveIndexView,
     DayArchiveView,
     MonthArchiveView,
     YearArchiveView,
 )
-from fs import path
 
+from bakery.filesystem import join_path
 from bakery.views import BuildableMixin
 
 logger = logging.getLogger(__name__)
@@ -58,10 +55,8 @@ class BuildableArchiveIndexView(ArchiveIndexView, BuildableMixin):
     def build_queryset(self) -> None:
         logger.debug("Building %s", self.build_path)
         self.request = self.create_request(self.build_path)
-        self.prep_directory(self.build_path)
-        target_path = path.join(
-            str(cast("str | PathLike[str]", settings.BUILD_DIR)), self.build_path
-        )
+        target_path = self.get_output_path(self.build_path)
+        self.prep_directory(target_path)
         self.build_file(target_path, self.get_content())
 
 
@@ -107,16 +102,11 @@ class BuildableYearArchiveView(YearArchiveView, BuildableMixin):
         would like your page at a different location. By default it
         will be built at self.get_url() + "/index.html"
         """
-        target_path = path.join(
-            str(
-                Path(cast("str | PathLike[str]", settings.BUILD_DIR))
-                / self.get_url().lstrip("/")
-            )
+        target_path = self.get_output_path(
+            join_path(self.get_url().lstrip("/"), "index.html")
         )
-        if not self.fs.exists(target_path):
-            logger.debug("Creating %s", target_path)
-            self.fs.makedirs(target_path)
-        return cast("str", path.join(target_path, "index.html"))
+        self.prep_directory(target_path)
+        return target_path
 
     def build_year(self, dt: date) -> None:
         """
@@ -143,7 +133,7 @@ class BuildableYearArchiveView(YearArchiveView, BuildableMixin):
         """
         self.year = str(dt.year)
         logger.debug("Unbuilding %s", self.year)
-        target_path = str(Path(self.get_build_path()).parent)
+        target_path = posixpath.dirname(self.get_build_path())
         if self.fs.exists(target_path):
             logger.debug("Removing %s", target_path)
             self.fs.removetree(target_path)
@@ -200,16 +190,11 @@ class BuildableMonthArchiveView(MonthArchiveView, BuildableMixin):
         would like your page at a different location. By default it
         will be built at self.get_url() + "/index.html"
         """
-        target_path = path.join(
-            str(
-                Path(cast("str | PathLike[str]", settings.BUILD_DIR))
-                / self.get_url().lstrip("/")
-            )
+        target_path = self.get_output_path(
+            join_path(self.get_url().lstrip("/"), "index.html")
         )
-        if not self.fs.exists(target_path):
-            logger.debug("Creating %s", target_path)
-            self.fs.makedirs(target_path)
-        return cast("str", path.join(target_path, "index.html"))
+        self.prep_directory(target_path)
+        return target_path
 
     def build_month(self, dt: date) -> None:
         """
@@ -238,7 +223,7 @@ class BuildableMonthArchiveView(MonthArchiveView, BuildableMixin):
         self.year = str(dt.year)
         self.month = str(dt.month)
         logger.debug("Building %s-%s", self.year, self.month)
-        target_path = str(Path(self.get_build_path()).parent)
+        target_path = posixpath.dirname(self.get_build_path())
         if self.fs.exists(target_path):
             logger.debug("Removing %s", target_path)
             self.fs.removetree(target_path)
@@ -311,16 +296,11 @@ class BuildableDayArchiveView(DayArchiveView, BuildableMixin):
         would like your page at a different location. By default it
         will be built at self.get_url() + "/index.html"
         """
-        target_path = path.join(
-            str(
-                Path(cast("str | PathLike[str]", settings.BUILD_DIR))
-                / self.get_url().lstrip("/")
-            )
+        target_path = self.get_output_path(
+            join_path(self.get_url().lstrip("/"), "index.html")
         )
-        if not self.fs.exists(target_path):
-            logger.debug("Creating %s", target_path)
-            self.fs.makedirs(target_path)
-        return str(Path(target_path) / "index.html")
+        self.prep_directory(target_path)
+        return target_path
 
     def build_day(self, dt: date) -> None:
         """
@@ -351,7 +331,7 @@ class BuildableDayArchiveView(DayArchiveView, BuildableMixin):
         self.month = str(dt.month)
         self.day = str(dt.day)
         logger.debug("Building %s-%s-%s", self.year, self.month, self.day)
-        target_path = str(Path(self.get_build_path()).parent)
+        target_path = posixpath.dirname(self.get_build_path())
         if self.fs.exists(target_path):
             logger.debug("Removing %s", target_path)
             self.fs.removetree(target_path)

--- a/bakery/views/detail.py
+++ b/bakery/views/detail.py
@@ -4,15 +4,14 @@ for building flat files.
 """
 
 import logging
-import os
+import posixpath
 from collections.abc import Callable
-from os import PathLike
 from typing import cast
 
-from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.views.generic import DetailView
-from fs import path
+
+from bakery.filesystem import join_path
 
 from .base import BuildableMixin
 
@@ -63,14 +62,11 @@ set a ``get_absolute_url`` method on the {obj.__class__.__name__} model or overr
         would like your detail page at a different location. By default it
         will be built at get_url() + "index.html"
         """
-        target_path = path.join(
-            str(cast("str | PathLike[str]", settings.BUILD_DIR)),
-            self.get_url(obj).lstrip("/"),
+        target_path = self.get_output_path(
+            join_path(self.get_url(obj).lstrip("/"), "index.html")
         )
-        if not self.fs.exists(target_path):
-            logger.debug("Creating %s", target_path)
-            self.fs.makedirs(target_path)
-        return cast("str", path.join(target_path, "index.html"))
+        self.prep_directory(target_path)
+        return target_path
 
     def set_kwargs(self, obj: object) -> None:
         slug_field = self.get_slug_field()
@@ -98,7 +94,7 @@ set a ``get_absolute_url`` method on the {obj.__class__.__name__} model or overr
         Deletes the directory at self.get_build_path.
         """
         logger.debug("Unbuilding %s", obj)
-        target_path = os.path.split(self.get_build_path(obj))[0]
+        target_path = posixpath.dirname(self.get_build_path(obj))
         if self.fs.exists(target_path):
             logger.debug("Removing %s", target_path)
             self.fs.removetree(target_path)

--- a/bakery/views/detail.py
+++ b/bakery/views/detail.py
@@ -65,7 +65,7 @@ set a ``get_absolute_url`` method on the {obj.__class__.__name__} model or overr
         target_path = self.get_output_path(
             join_path(self.get_url(obj).lstrip("/"), "index.html")
         )
-        self.prep_directory(target_path)
+        self._prep_output_directory(target_path)
         return target_path
 
     def set_kwargs(self, obj: object) -> None:

--- a/bakery/views/list.py
+++ b/bakery/views/list.py
@@ -6,9 +6,7 @@ for building flat files.
 import logging
 from collections.abc import Callable
 
-from django.conf import settings
 from django.views.generic import ListView
-from fs import path
 
 from .base import BuildableMixin
 
@@ -45,6 +43,6 @@ class BuildableListView(ListView, BuildableMixin):
     def build_queryset(self) -> None:
         logger.debug("Building %s", self.build_path)
         self.request = self.create_request(self.build_path)
-        self.prep_directory(self.build_path)
-        target_path = path.join(str(settings.BUILD_DIR), self.build_path)
+        target_path = self.get_output_path(self.build_path)
+        self.prep_directory(target_path)
         self.build_file(target_path, self.get_content())

--- a/bakery/views/list.py
+++ b/bakery/views/list.py
@@ -44,5 +44,5 @@ class BuildableListView(ListView, BuildableMixin):
         logger.debug("Building %s", self.build_path)
         self.request = self.create_request(self.build_path)
         target_path = self.get_output_path(self.build_path)
-        self.prep_directory(target_path)
+        self.prep_directory(self.build_path)
         self.build_file(target_path, self.get_content())

--- a/docs/settingsvariables.md
+++ b/docs/settingsvariables.md
@@ -53,6 +53,10 @@ BUILD_DIR = os.path.join(__file__, "build")
     to either URL keep all Bakery output below that root. Other historical
     PyFilesystem plugin URLs are not supported by this migration.
 
+    With the unrooted default ``osfs:///`` backend, ``BUILD_DIR`` must name a
+    directory. Empty and ``"."`` build directories are only safe with a rooted
+    backend URL.
+
     .. code-block:: python
 
         BAKERY_FILESYSTEM = "mem://"

--- a/docs/settingsvariables.md
+++ b/docs/settingsvariables.md
@@ -39,13 +39,19 @@ BUILD_DIR = os.path.join(__file__, "build")
 ```{eval-rst}
 .. envvar:: BAKERY_FILESYSTEM
 
-    Files are built using `PyFilesystem <https://docs.pyfilesystem.org/en/latest/index.html>`_, a module that provides a common interface to a variety of filesystem backends. The default setting is the `OS filesystem <https://docs.pyfilesystem.org/en/latest/reference/osfs.html>`_ backend that saves files to the local directory structure. If you don't set the variable, it will operates as follows:
+    Files are built using `fsspec <https://filesystem-spec.readthedocs.io/>`_,
+    which provides the filesystem interface used by Bakery. The default setting
+    is the local filesystem backend. If you don't set the variable, it operates
+    as follows:
 
     .. code-block:: python
 
         BAKERY_FILESYSTEM = "osfs:///"
 
-    Here's how you could change to an `in-memory backend <https://docs.pyfilesystem.org/en/latest/reference/memoryfs.html>`_ instead. The complete list of alternatives are documented `here <https://docs.pyfilesystem.org/en/latest/builtin.html>`_.
+    The supported legacy configuration strings are ``osfs:///`` for the local
+    filesystem and ``mem://`` for an in-memory filesystem. Root paths appended
+    to either URL keep all Bakery output below that root. Other historical
+    PyFilesystem plugin URLs are not supported by this migration.
 
     .. code-block:: python
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=80,<81", "setuptools-scm>=10.2.1"]
+requires = ["setuptools>=80", "setuptools-scm>=10.2.1"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -14,8 +14,7 @@ authors = [{ name = "Ben Welsh", email = "b@palewi.re" }]
 dependencies = [
     "Django>=5.2,<6.2",
     "boto3>=1.4.4",
-    "fs>=2.0.17",
-    "setuptools<81",
+    "fsspec>=2026.7.0",
 ]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
@@ -194,4 +193,4 @@ unused-ignore-comment = "error"
 extend_exclude = ["bakery/tests", "docs", "example"]
 
 [tool.deptry.per_rule_ignores]
-DEP002 = ["celery", "setuptools"]
+DEP002 = ["celery"]

--- a/uv.lock
+++ b/uv.lock
@@ -50,15 +50,6 @@ wheels = [
 ]
 
 [[package]]
-name = "appdirs"
-version = "1.4.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
-]
-
-[[package]]
 name = "asgiref"
 version = "3.12.1"
 source = { registry = "https://pypi.org/simple" }
@@ -770,8 +761,7 @@ dependencies = [
     { name = "boto3" },
     { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "fs" },
-    { name = "setuptools" },
+    { name = "fsspec" },
 ]
 
 [package.optional-dependencies]
@@ -813,8 +803,7 @@ requires-dist = [
     { name = "boto3", specifier = ">=1.4.4" },
     { name = "celery", marker = "extra == 'celery'", specifier = ">=5.5" },
     { name = "django", specifier = ">=5.2,<6.2" },
-    { name = "fs", specifier = ">=2.0.17" },
-    { name = "setuptools", specifier = "<81" },
+    { name = "fsspec", specifier = ">=2026.7.0" },
 ]
 provides-extras = ["celery"]
 
@@ -865,17 +854,12 @@ wheels = [
 ]
 
 [[package]]
-name = "fs"
-version = "2.4.16"
+name = "fsspec"
+version = "2026.7.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "appdirs" },
-    { name = "setuptools" },
-    { name = "six" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5d/a9/af5bfd5a92592c16cdae5c04f68187a309be8a146b528eac3c6e30edbad2/fs-2.4.16.tar.gz", hash = "sha256:ae97c7d51213f4b70b6a958292530289090de3a7e15841e108fbe144f069d313", size = 187441, upload-time = "2022-05-02T09:25:54.22Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/00/78/f34251dadb8f3921264a1d9b8946f5e542014ee2614b285261b4e40e6775/fsspec-2026.7.0.tar.gz", hash = "sha256:c803c40f4cf860b49dea58ee3e1c33cb9c790520e233537e1340049f89b82a88", size = 317040, upload-time = "2026-07-28T16:34:51.052Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/5c/a3d95dc1ec6cdeb032d789b552ecc76effa3557ea9186e1566df6aac18df/fs-2.4.16-py2.py3-none-any.whl", hash = "sha256:660064febbccda264ae0b6bace80a8d1be9e089e0a5eb2427b7d517f9a91545c", size = 135261, upload-time = "2022-05-02T09:25:52.363Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/3c/6a2bf344106328fd04963664a60b9bb6496fc25df8e962fcdc1367285fb9/fsspec-2026.7.0-py3-none-any.whl", hash = "sha256:b57ddbafedfaef7018c1ecab32aa200a9d7ca26b77965f64e48b70061249d279", size = 206583, upload-time = "2026-07-28T16:34:49.538Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replaces the runtime `fs` dependency with `fsspec` and removes the runtime setuptools cap that existed for PyFilesystem2 compatibility.
- Preserves the documented `BAKERY_FILESYSTEM` forms: `osfs:///` for local output and `mem://` for in-memory output; URL root paths keep all output below the selected root.
- Defers unsupported historical PyFilesystem plugin URLs. This migration translates only the documented legacy forms.
- Fixes the filesystem contract for backend-relative static, media, rendered, gzip, pooled, and unbuild output; paths normalize Windows separators and cannot escape `BUILD_DIR`.
- Follow-up fixes preserve the public BUILD_DIR-relative `prep_directory()` convention, treat Windows drive roots as unrooted defaults, stream local static/media copies, normalize rooted empty build directories, and reject unsafe unrooted root operations.

## Validation
- `make verify`
- `make hooks`
- Focused filesystem contracts cover rooted local/memory output, Windows separators and drive roots, traversal rejection, pooled deterministic gzip, build/unbuild, public directory preparation, streaming local copies, empty build directories, and unsafe root-operation rejection.
- Clean Python 3.14.7 wheel installation using setuptools 84.0.0; Django initialization and `bakery.views` import succeeded without `fs` or `pkg_resources`.
