### PR TITLE
Mark static build requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to django-bakery are documented here. The format follows
   `BAKERY_FILESYSTEM="s3://bucket[/prefix]"`.
 - Add a uv-based development container and worktree-aware bootstrap command.
 - Add contributor, agent, release, and security guidance.
+- Mark static build requests with the `X-Bakery: true` header.
 
 ### Changed
 

--- a/bakery/tests/test_support.py
+++ b/bakery/tests/test_support.py
@@ -10,7 +10,7 @@ from django.urls import resolve
 from bakery import feeds, static_urls
 from bakery.management.commands import batch_delete_s3_objects, buildserver
 from bakery.management.commands import publish as publish_command
-from bakery.views import BuildableDetailView, BuildableListView
+from bakery.views import BuildableDetailView, BuildableListView, BuildableMixin
 
 
 def test_buildserver_uses_static_urlconf() -> None:
@@ -121,6 +121,15 @@ def test_detail_view_supports_dynamic_absolute_url() -> None:
             raise AttributeError(name)
 
     assert BuildableDetailView().get_url(DynamicObject()) == "/dynamic/"
+
+
+def test_buildable_request_marks_static_builds() -> None:
+    request = BuildableMixin().create_request("/example/?preview=true")
+
+    assert request.method == "GET"
+    assert request.get_full_path() == "/example/?preview=true"
+    assert request.headers["X-Bakery"] == "true"
+    assert request.META["HTTP_X_BAKERY"] == "true"
 
 
 @override_settings(BUILD_DIR=Path("/tmp/build"))

--- a/bakery/views/base.py
+++ b/bakery/views/base.py
@@ -80,11 +80,17 @@ class BuildableMixin:
         """
         Returns a GET request object for use when building views.
 
+        The request includes the ``X-Bakery: true`` header so templates and
+        views can identify static builds.
+
         If inheriting views require additional request attributes
         (e.g. user, site), override this method and define those
         attributes on the returned object.
         """
-        return cast("HttpRequest", RequestFactory().get(str(path)))
+        return cast(
+            "HttpRequest",
+            RequestFactory().get(str(path), headers={"X-Bakery": "true"}),
+        )
 
     def get_content(self) -> bytes:
         """

--- a/docs/buildableviews.md
+++ b/docs/buildableviews.md
@@ -2,6 +2,27 @@
 
 Django's [class-based views](https://docs.djangoproject.com/en/dev/topics/class-based-views/)  are used to render HTML pages to flat files. Putting all the pieces together is a little tricky at first, particularly if you haven't studied [the Django source code](https://github.com/django/django/tree/master/django/views/generic) or lack experience [working with Python classes](http://www.diveintopython.net/object_oriented_framework/defining_classes.html) in general. But if you figure it out, we think it's worth the trouble.
 
+## Static build requests
+
+During a static build, django-bakery creates an ordinary GET request with the
+`X-Bakery: true` header. Use it to render build-specific content in a view:
+
+```python
+if request.headers.get("X-Bakery") == "true":
+    # Render content intended only for the static site.
+```
+
+Templates can check the same marker through `request.META`:
+
+```django
+{% if request.META.HTTP_X_BAKERY == "true" %}
+  {# Render content intended only for the static site. #}
+{% endif %}
+```
+
+The header identifies django-bakery's generated requests only. Do not use it
+as an authorization or security check.
+
 ## BuildableTemplateView
 
 ```{eval-rst}


### PR DESCRIPTION
## Summary

Adds an `X-Bakery: true` header to django-bakery's generated GET requests. Views and templates can use it to distinguish static builds without changing normal request behavior.

## Related Issue

Closes #144

## Change Type

- [ ] Bug fix
- [x] Feature
- [x] Documentation
- [ ] Maintenance
- [ ] Breaking change

## Acceptance Criteria

- [x] The behavior matches the issue or request.
- [x] Relevant edge cases are covered.

## Validation

- `uv run --no-env-file pytest bakery/tests/test_support.py`
- `make docs-check`
- `uv run --no-env-file ruff check bakery/views/base.py bakery/tests/test_support.py`
- `uv run --no-env-file ruff format --check bakery/views/base.py bakery/tests/test_support.py`

## Documentation and Release Notes

- [x] Documentation is updated, or no update is needed.
- [x] `CHANGELOG.md` is updated for a user-facing, compatibility, or security change.