### PR TITLE
Fix gzip headers in buildserver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ All notable changes to django-bakery are documented here. The format follows
 
 ### Fixed
 
+- Serve gzip-compressed baked files from `buildserver` with the required
+  `Content-Encoding: gzip` header.
 - Keep filesystem output paths rooted when using Windows drive roots and empty
   build-directory settings.
 - Reject unrooted filesystem root operations and unsupported legacy filesystem

--- a/bakery/static_views.py
+++ b/bakery/static_views.py
@@ -91,18 +91,26 @@ def serve(
         raise Http404(f'"{fullpath}" does not exist')
     # Respect the If-Modified-Since header.
     statobj = fullpath.stat()
-    mimetype = mimetypes.guess_type(str(fullpath))[0] or "application/octet-stream"
+    mimetype, content_encoding = mimetypes.guess_type(str(fullpath))
+    mimetype = mimetype or "application/octet-stream"
+    if content_encoding is None:
+        with fullpath.open("rb") as file:
+            if file.read(2) == b"\x1f\x8b":
+                content_encoding = "gzip"
     if not was_modified_since(
         request.META.get("HTTP_IF_MODIFIED_SINCE"),
         statobj[stat.ST_MTIME],
         statobj[stat.ST_SIZE],
     ):
-        return HttpResponseNotModified(content_type=mimetype)
-    with fullpath.open("rb") as file:
-        contents = file.read()
-    response = HttpResponse(contents, content_type=mimetype)
-    response["Last-Modified"] = http_date(statobj[stat.ST_MTIME])
-    response["Content-Length"] = len(contents)
+        response = HttpResponseNotModified(content_type=mimetype)
+    else:
+        with fullpath.open("rb") as file:
+            contents = file.read()
+        response = HttpResponse(contents, content_type=mimetype)
+        response["Last-Modified"] = http_date(statobj[stat.ST_MTIME])
+        response["Content-Length"] = len(contents)
+    if content_encoding:
+        response["Content-Encoding"] = content_encoding
     return response
 
 

--- a/bakery/tests/test_support.py
+++ b/bakery/tests/test_support.py
@@ -1,3 +1,4 @@
+import gzip
 from pathlib import Path
 from unittest.mock import Mock, call, patch
 
@@ -73,6 +74,49 @@ def test_static_urls_catch_all_pattern_uses_build_directory() -> None:
         "show_indexes": True,
         "default": "index.html",
     }
+
+
+def test_static_view_serves_gzipped_baked_content(tmp_path: Path) -> None:
+    content = b"<h1>Built page</h1>"
+    (tmp_path / "index.html").write_bytes(gzip.compress(content, mtime=0))
+
+    response = static_urls.serve(
+        RequestFactory().get("/"),
+        "",
+        document_root=tmp_path,
+        show_indexes=True,
+        default="index.html",
+    )
+
+    assert response["Content-Encoding"] == "gzip"
+    assert gzip.decompress(response.content) == content
+
+    not_modified_response = static_urls.serve(
+        RequestFactory().get("/", HTTP_IF_MODIFIED_SINCE=response["Last-Modified"]),
+        "",
+        document_root=tmp_path,
+        show_indexes=True,
+        default="index.html",
+    )
+
+    assert not_modified_response.status_code == 304
+    assert not_modified_response["Content-Encoding"] == "gzip"
+
+
+def test_static_view_serves_uncompressed_baked_content(tmp_path: Path) -> None:
+    content = b"<h1>Built page</h1>"
+    (tmp_path / "index.html").write_bytes(content)
+
+    response = static_urls.serve(
+        RequestFactory().get("/"),
+        "",
+        document_root=tmp_path,
+        show_indexes=True,
+        default="index.html",
+    )
+
+    assert "Content-Encoding" not in response
+    assert response.content == content
 
 
 def test_static_view_rejects_symlink_outside_document_root(tmp_path: Path) -> None:

--- a/docs/managementcommands.md
+++ b/docs/managementcommands.md
@@ -59,6 +59,11 @@ $ python manage.py build yourapp.views.DummyListView
 Starts a variation of Django's [runserver](https://docs.djangoproject.com/en/dev/ref/django-admin/#runserver-port-or-address-port) designed to serve the static files you've built
 in the build directory.
 
+When `BAKERY_GZIP = True` was used to create the build, `buildserver` detects
+the compressed files and sends `Content-Encoding: gzip`; no additional
+buildserver setting is needed. Like Django's `runserver`, this command is for
+development only.
+
 ```bash
 $ python manage.py buildserver
 ```


### PR DESCRIPTION
## Summary
- detect gzip-compressed baked files before serving them from `buildserver`
- return `Content-Encoding: gzip` for normal and 304 responses while preserving plain-file behavior
- document that no additional buildserver setting is required

## Validation
- `uv run --no-env-file pytest bakery/tests/test_support.py`
- `uv run --no-env-file ruff check bakery/static_views.py bakery/tests/test_support.py`
- `uv run --no-env-file ruff format --check bakery/static_views.py bakery/tests/test_support.py`
- `uv run --no-env-file ty check bakery/static_views.py`
- `make docs-check`

Closes #140