### PR TITLE
Harden S3 filesystem output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,8 @@ All notable changes to django-bakery are documented here. The format follows
 - Reject unrooted filesystem root operations and unsupported legacy filesystem
   plugin URLs.
 - Preserve S3 buckets and their configuration during build and unbuild cleanup,
-  require configured S3 buckets to already exist, and write S3 object content
-  type and gzip encoding metadata.
+  validate configured S3 buckets when a build or unbuild starts, and write S3
+  object content type and generated-gzip encoding metadata.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ All notable changes to django-bakery are documented here. The format follows
   build-directory settings.
 - Reject unrooted filesystem root operations and unsupported legacy filesystem
   plugin URLs.
+- Preserve S3 buckets and their configuration during build and unbuild cleanup,
+  require configured S3 buckets to already exist, and write S3 object content
+  type and gzip encoding metadata.
 
 ### Removed
 

--- a/bakery/filesystem.py
+++ b/bakery/filesystem.py
@@ -3,13 +3,13 @@
 import mimetypes
 import posixpath
 import re
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from os import PathLike
 from typing import BinaryIO, Protocol, cast
 from urllib.parse import urlsplit
 
-from boto3.exceptions import botocore
+from botocore.exceptions import BotoCoreError
 from fsspec.core import url_to_fs
 
 
@@ -29,6 +29,14 @@ class _Filesystem(Protocol):
     def find(self, path: str) -> list[str]: ...
 
 
+class _S3Filesystem(_Filesystem, Protocol):
+    """The configured s3fs operations used for bucket-safe cleanup."""
+
+    def call_s3(
+        self, method: str, *args: object, **kwargs: object
+    ) -> Mapping[str, object]: ...
+
+
 @dataclass(frozen=True)
 class ObjectMetadata:
     """HTTP metadata that can be applied to a written output object."""
@@ -39,11 +47,8 @@ class ObjectMetadata:
 
 def object_metadata(path: str | PathLike[str]) -> ObjectMetadata:
     """Infer HTTP metadata for an output path."""
-    content_type, content_encoding = mimetypes.guess_type(str(path))
-    return ObjectMetadata(
-        content_type=content_type or "application/octet-stream",
-        content_encoding=content_encoding,
-    )
+    content_type, _ = mimetypes.guess_type(str(path))
+    return ObjectMetadata(content_type=content_type or "application/octet-stream")
 
 
 def normalize_path(path: str | PathLike[str]) -> str:
@@ -103,18 +108,7 @@ class RootedFilesystem:
                 *(part for part in prefix_parts if part not in {"", "."}),
             )
             filesystem, _ = url_to_fs(f"s3://{parsed.netloc}")
-            s3_filesystem = cast("_Filesystem", filesystem)
-            try:
-                s3_filesystem.info(parsed.netloc)
-            except FileNotFoundError as exc:
-                raise ValueError(
-                    f"Configured S3 bucket {parsed.netloc!r} must already exist."
-                ) from exc
-            except (OSError, botocore.exceptions.BotoCoreError) as exc:
-                raise ValueError(
-                    f"Configured S3 bucket {parsed.netloc!r} is not accessible."
-                ) from exc
-            return cls(s3_filesystem, root, s3_bucket=parsed.netloc)
+            return cls(cast("_Filesystem", filesystem), root, s3_bucket=parsed.netloc)
         else:
             raise ValueError(
                 "BAKERY_FILESYSTEM must use a supported osfs:///, mem://, or "
@@ -130,6 +124,21 @@ class RootedFilesystem:
         if self.s3_bucket:
             return
         self.filesystem.makedirs(self._resolve(path), exist_ok=True)
+
+    def validate(self) -> None:
+        """Check a configured S3 bucket immediately before command I/O."""
+        if not self.s3_bucket:
+            return
+        try:
+            self.filesystem.info(self.s3_bucket)
+        except FileNotFoundError as exc:
+            raise ValueError(
+                f"Configured S3 bucket {self.s3_bucket!r} must already exist."
+            ) from exc
+        except (OSError, BotoCoreError) as exc:
+            raise ValueError(
+                f"Configured S3 bucket {self.s3_bucket!r} is not accessible."
+            ) from exc
 
     def open(
         self,
@@ -151,16 +160,25 @@ class RootedFilesystem:
             self.filesystem.rm(resolved, recursive=True)
             return
 
-        object_paths = [
-            candidate
+        root_key = self._s3_key(resolved)
+        object_keys = [
+            key
             for candidate in self.filesystem.find(resolved)
-            if self._is_s3_object_within(candidate, resolved)
+            if (key := self._s3_key(candidate)) is not None
+            and self._is_s3_key_within(key, root_key)
         ]
-        for start in range(0, len(object_paths), 1000):
-            batch = object_paths[start : start + 1000]
-            deleted = self.filesystem.rm(batch, recursive=False)
-            if set(deleted or []) != set(batch):
-                raise OSError(f"Unable to delete all objects below {resolved!r}.")
+        s3_filesystem = cast("_S3Filesystem", self.filesystem)
+        for start in range(0, len(object_keys), 1000):
+            keys = object_keys[start : start + 1000]
+            response = s3_filesystem.call_s3(
+                "delete_objects",
+                Bucket=self.s3_bucket,
+                Delete={
+                    "Objects": [{"Key": key} for key in keys],
+                    "Quiet": False,
+                },
+            )
+            self._raise_s3_delete_errors(response, resolved)
 
     def copy(self, source: str | PathLike[str], target: str | PathLike[str]) -> None:
         self.filesystem.copy(self._resolve(source), self._resolve(target))
@@ -194,11 +212,34 @@ class RootedFilesystem:
             return path.lstrip("/")
         return path.removeprefix(f"{self.root}/").lstrip("/")
 
-    def _is_s3_object_within(self, path: str, root: str) -> bool:
-        """Return whether an enumerated S3 key is inside the selected root."""
-        if path == self.s3_bucket:
-            return False
-        return path == root or path.startswith(f"{root.rstrip('/')}/")
+    def _s3_key(self, path: str) -> str | None:
+        """Return a literal S3 key, never a bucket-like fsspec path."""
+        if not self.s3_bucket or path == self.s3_bucket:
+            return None
+        bucket_prefix = f"{self.s3_bucket}/"
+        if not path.startswith(bucket_prefix):
+            return None
+        key = path.removeprefix(bucket_prefix)
+        return key or None
+
+    @staticmethod
+    def _is_s3_key_within(key: str, root_key: str | None) -> bool:
+        """Return whether an object key belongs to the selected cleanup root."""
+        return root_key is None or key == root_key or key.startswith(f"{root_key}/")
+
+    @staticmethod
+    def _raise_s3_delete_errors(response: Mapping[str, object], path: str) -> None:
+        """Raise any per-object errors reported by a DeleteObjects response."""
+        errors = response.get("Errors", [])
+        if not isinstance(errors, list) or not errors:
+            return
+        failed_keys = [
+            str(error.get("Key", "<unknown>"))
+            for error in errors
+            if isinstance(error, Mapping)
+        ]
+        detail = ", ".join(failed_keys) or "<unknown>"
+        raise OSError(f"Unable to delete S3 objects below {path!r}: {detail}.")
 
     @staticmethod
     def _normalize_root(root: str) -> str:

--- a/bakery/filesystem.py
+++ b/bakery/filesystem.py
@@ -1,27 +1,49 @@
 """Rooted filesystem support for bakery output."""
 
+import mimetypes
 import posixpath
 import re
 from collections.abc import Iterator
+from dataclasses import dataclass
 from os import PathLike
 from typing import BinaryIO, Protocol, cast
 from urllib.parse import urlsplit
 
+from boto3.exceptions import botocore
 from fsspec.core import url_to_fs
 
 
 class _Filesystem(Protocol):
     def exists(self, path: str) -> bool: ...
 
+    def info(self, path: str) -> object: ...
+
     def makedirs(self, path: str, exist_ok: bool) -> None: ...
 
-    def open(self, path: str, mode: str) -> BinaryIO: ...
+    def open(self, path: str, mode: str, **kwargs: object) -> BinaryIO: ...
 
-    def rm(self, path: str, recursive: bool) -> None: ...
+    def rm(self, path: str | list[str], recursive: bool) -> list[str] | None: ...
 
     def copy(self, source: str, target: str) -> None: ...
 
     def find(self, path: str) -> list[str]: ...
+
+
+@dataclass(frozen=True)
+class ObjectMetadata:
+    """HTTP metadata that can be applied to a written output object."""
+
+    content_type: str
+    content_encoding: str | None = None
+
+
+def object_metadata(path: str | PathLike[str]) -> ObjectMetadata:
+    """Infer HTTP metadata for an output path."""
+    content_type, content_encoding = mimetypes.guess_type(str(path))
+    return ObjectMetadata(
+        content_type=content_type or "application/octet-stream",
+        content_encoding=content_encoding,
+    )
 
 
 def normalize_path(path: str | PathLike[str]) -> str:
@@ -45,9 +67,16 @@ def is_root_path(path: str | PathLike[str]) -> bool:
 class RootedFilesystem:
     """Expose paths relative to a configured fsspec filesystem URL."""
 
-    def __init__(self, filesystem: _Filesystem, root: str = "") -> None:
+    def __init__(
+        self,
+        filesystem: _Filesystem,
+        root: str = "",
+        *,
+        s3_bucket: str | None = None,
+    ) -> None:
         self.filesystem = filesystem
         self.root = self._normalize_root(root)
+        self.s3_bucket = s3_bucket
 
     @classmethod
     def from_url(cls, url: str) -> "RootedFilesystem":
@@ -74,7 +103,18 @@ class RootedFilesystem:
                 *(part for part in prefix_parts if part not in {"", "."}),
             )
             filesystem, _ = url_to_fs(f"s3://{parsed.netloc}")
-            return cls(cast("_Filesystem", filesystem), root)
+            s3_filesystem = cast("_Filesystem", filesystem)
+            try:
+                s3_filesystem.info(parsed.netloc)
+            except FileNotFoundError as exc:
+                raise ValueError(
+                    f"Configured S3 bucket {parsed.netloc!r} must already exist."
+                ) from exc
+            except (OSError, botocore.exceptions.BotoCoreError) as exc:
+                raise ValueError(
+                    f"Configured S3 bucket {parsed.netloc!r} is not accessible."
+                ) from exc
+            return cls(s3_filesystem, root, s3_bucket=parsed.netloc)
         else:
             raise ValueError(
                 "BAKERY_FILESYSTEM must use a supported osfs:///, mem://, or "
@@ -87,13 +127,40 @@ class RootedFilesystem:
         return self.filesystem.exists(self._resolve(path))
 
     def makedirs(self, path: str | PathLike[str]) -> None:
+        if self.s3_bucket:
+            return
         self.filesystem.makedirs(self._resolve(path), exist_ok=True)
 
-    def open(self, path: str | PathLike[str], mode: str) -> BinaryIO:
+    def open(
+        self,
+        path: str | PathLike[str],
+        mode: str,
+        *,
+        metadata: ObjectMetadata | None = None,
+    ) -> BinaryIO:
+        if self.s3_bucket and metadata:
+            kwargs: dict[str, str] = {"ContentType": metadata.content_type}
+            if metadata.content_encoding:
+                kwargs["ContentEncoding"] = metadata.content_encoding
+            return self.filesystem.open(self._resolve(path), mode, **kwargs)
         return self.filesystem.open(self._resolve(path), mode)
 
     def removetree(self, path: str | PathLike[str]) -> None:
-        self.filesystem.rm(self._resolve(path), recursive=True)
+        resolved = self._resolve(path)
+        if not self.s3_bucket:
+            self.filesystem.rm(resolved, recursive=True)
+            return
+
+        object_paths = [
+            candidate
+            for candidate in self.filesystem.find(resolved)
+            if self._is_s3_object_within(candidate, resolved)
+        ]
+        for start in range(0, len(object_paths), 1000):
+            batch = object_paths[start : start + 1000]
+            deleted = self.filesystem.rm(batch, recursive=False)
+            if set(deleted or []) != set(batch):
+                raise OSError(f"Unable to delete all objects below {resolved!r}.")
 
     def copy(self, source: str | PathLike[str], target: str | PathLike[str]) -> None:
         self.filesystem.copy(self._resolve(source), self._resolve(target))
@@ -126,6 +193,12 @@ class RootedFilesystem:
         if not self.root:
             return path.lstrip("/")
         return path.removeprefix(f"{self.root}/").lstrip("/")
+
+    def _is_s3_object_within(self, path: str, root: str) -> bool:
+        """Return whether an enumerated S3 key is inside the selected root."""
+        if path == self.s3_bucket:
+            return False
+        return path == root or path.startswith(f"{root.rstrip('/')}/")
 
     @staticmethod
     def _normalize_root(root: str) -> str:

--- a/bakery/management/commands/build.py
+++ b/bakery/management/commands/build.py
@@ -1,7 +1,6 @@
 import gzip
 import io
 import logging
-import mimetypes
 import multiprocessing
 import os
 import posixpath
@@ -21,10 +20,12 @@ from django.utils.encoding import smart_str
 
 from bakery import DEFAULT_GZIP_CONTENT_TYPES
 from bakery.filesystem import (
+    ObjectMetadata,
     RootedFilesystem,
     is_root_path,
     join_path,
     normalize_path,
+    object_metadata,
 )
 
 logger = logging.getLogger(__name__)
@@ -310,13 +311,10 @@ Will use settings.BUILD_DIR by default.",
         if not self.fs.exists(target_dir):
             self.fs.makedirs(target_dir)
 
-        # determine the mimetype of the file
-        guess = mimetypes.guess_type(source_path)
-        content_type = guess[0]
-        encoding = guess[1]
+        metadata = object_metadata(source_path)
 
         # If it isn't a file want to gzip...
-        if content_type not in self.gzip_file_match:
+        if metadata.content_type not in self.gzip_file_match:
             # just copy it to the target.
             logger.debug(
                 "Copying osfs://%s to %s%s because its filetype isn't on the whitelist",
@@ -327,7 +325,7 @@ Will use settings.BUILD_DIR by default.",
             self.copy_local_file(source_path, target_path)
 
         # # if the file is already gzipped
-        elif encoding == "gzip":
+        elif metadata.content_encoding == "gzip":
             logger.debug(
                 "Copying osfs://%s to %s%s because it's already gzipped",
                 source_path,
@@ -358,7 +356,11 @@ Will use settings.BUILD_DIR by default.",
                     f.write(source_file.read())
 
                 # Write that buffer out to the filesystem
-                with self.fs.open(smart_str(target_path), "wb") as outfile:
+                with self.fs.open(
+                    smart_str(target_path),
+                    "wb",
+                    metadata=ObjectMetadata(metadata.content_type, "gzip"),
+                ) as outfile:
                     outfile.write(data_buffer.getvalue())
 
     def copytree(self, source_dir: str, target_dir: str) -> None:
@@ -376,6 +378,8 @@ Will use settings.BUILD_DIR by default.",
             self.fs.makedirs(target_dir)
         with (
             Path(source_path).open("rb") as source,
-            self.fs.open(target_path, "wb") as target,
+            self.fs.open(
+                target_path, "wb", metadata=object_metadata(source_path)
+            ) as target,
         ):
             shutil.copyfileobj(source, target)

--- a/bakery/management/commands/build.py
+++ b/bakery/management/commands/build.py
@@ -1,6 +1,7 @@
 import gzip
 import io
 import logging
+import mimetypes
 import multiprocessing
 import os
 import posixpath
@@ -145,6 +146,8 @@ Will use settings.BUILD_DIR by default.",
             and not self.fs.root
         ):
             raise CommandError("BUILD_DIR must not target an unrooted filesystem root.")
+        if isinstance(self.fs, RootedFilesystem):
+            self.fs.validate()
 
         # If the build dir doesn't exist make it
         if not self.fs.exists(self.build_dir):
@@ -324,10 +327,10 @@ Will use settings.BUILD_DIR by default.",
             )
             self.copy_local_file(source_path, target_path)
 
-        # # if the file is already gzipped
-        elif metadata.content_encoding == "gzip":
+        # Do not apply a second encoding to an already compressed file.
+        elif mimetypes.guess_type(source_path)[1] is not None:
             logger.debug(
-                "Copying osfs://%s to %s%s because it's already gzipped",
+                "Copying osfs://%s to %s%s because it is already compressed",
                 source_path,
                 self.fs_name,
                 target_path,

--- a/bakery/management/commands/unbuild.py
+++ b/bakery/management/commands/unbuild.py
@@ -17,6 +17,8 @@ class Command(BaseCommand):
             and not filesystem.root
         ):
             raise CommandError("BUILD_DIR must not target an unrooted filesystem root.")
+        if isinstance(filesystem, RootedFilesystem):
+            filesystem.validate()
         if filesystem.exists(build_dir):
             self.stdout.write("Clearing the build directory\n")
             filesystem.removetree(build_dir)

--- a/bakery/tests/test_filesystem_contract.py
+++ b/bakery/tests/test_filesystem_contract.py
@@ -2,6 +2,7 @@
 
 import gzip
 import io
+import json
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -10,13 +11,14 @@ from unittest.mock import patch
 
 import boto3
 import pytest
+from boto3.exceptions import botocore
 from django.apps import apps
 from django.core.management import call_command
 from django.core.management.base import CommandError
 from moto.server import ThreadedMotoServer
 from s3fs import S3FileSystem
 
-from bakery.filesystem import RootedFilesystem, _Filesystem
+from bakery.filesystem import ObjectMetadata, RootedFilesystem, _Filesystem
 from bakery.management.commands.build import Command
 from bakery.views import BuildableTemplateView
 from bakery.views.base import BuildableMixin
@@ -34,7 +36,9 @@ class WritableFilesystem(Protocol):
 
     def makedirs(self, path: str) -> None: ...
 
-    def open(self, path: str, mode: str) -> BinaryIO: ...
+    def open(
+        self, path: str, mode: str, *, metadata: ObjectMetadata | None = None
+    ) -> BinaryIO: ...
 
     def removetree(self, path: str) -> None: ...
 
@@ -280,6 +284,11 @@ def test_s3_rebuild_and_unbuild_only_remove_the_build_directory(
     s3_client.put_object(
         Bucket="bakery-cleanup", Key="published/keep.txt", Body=b"keep"
     )
+    s3_client.put_object(
+        Bucket="bakery-cleanup",
+        Key="published/site-sibling.txt",
+        Body=b"sibling",
+    )
     filesystem = RootedFilesystem.from_url(filesystem_name)
 
     with configured_filesystem(filesystem, filesystem_name):
@@ -304,9 +313,110 @@ def test_s3_rebuild_and_unbuild_only_remove_the_build_directory(
     assert rebuilt_keys == {
         "outside.txt",
         "published/keep.txt",
+        "published/site-sibling.txt",
         "published/site/pages/index.html",
     }
-    assert unbuilt_keys == {"outside.txt", "published/keep.txt"}
+    assert unbuilt_keys == {
+        "outside.txt",
+        "published/keep.txt",
+        "published/site-sibling.txt",
+    }
+
+
+@pytest.mark.parametrize("build_dir", ["", ".", "/"])
+def test_s3_bucket_root_cleanup_preserves_bucket_configuration(
+    settings, s3_client, build_dir: str
+) -> None:
+    bucket = "bakery-root-cleanup"
+    filesystem_name = f"s3://{bucket}"
+    website = {"IndexDocument": {"Suffix": "index.html"}}
+    policy = json.dumps(
+        {
+            "Version": "2012-10-17",
+            "Statement": [
+                {
+                    "Effect": "Allow",
+                    "Principal": "*",
+                    "Action": "s3:GetObject",
+                    "Resource": f"arn:aws:s3:::{bucket}/*",
+                }
+            ],
+        }
+    )
+    settings.BUILD_DIR = build_dir
+    settings.BAKERY_FILESYSTEM = filesystem_name
+    settings.BAKERY_VIEWS = (
+        "bakery.tests.test_filesystem_contract.FilesystemContractView",
+    )
+
+    s3_client.create_bucket(Bucket=bucket)
+    s3_client.put_bucket_website(Bucket=bucket, WebsiteConfiguration=website)
+    s3_client.put_bucket_policy(Bucket=bucket, Policy=policy)
+    s3_client.put_object(Bucket=bucket, Key="stale.txt", Body=b"stale")
+    filesystem = RootedFilesystem.from_url(filesystem_name)
+
+    with configured_filesystem(filesystem, filesystem_name):
+        call_command("build", skip_static=True, skip_media=True)
+        rebuilt_keys = {
+            item["Key"]
+            for item in s3_client.list_objects_v2(Bucket=bucket).get("Contents", [])
+        }
+        call_command("unbuild")
+
+    assert rebuilt_keys == {"pages/index.html"}
+    assert not s3_client.list_objects_v2(Bucket=bucket).get("Contents", [])
+    assert (
+        s3_client.head_bucket(Bucket=bucket)["ResponseMetadata"]["HTTPStatusCode"]
+        == 200
+    )
+    assert (
+        s3_client.get_bucket_website(Bucket=bucket)["IndexDocument"]
+        == website["IndexDocument"]
+    )
+    assert s3_client.get_bucket_policy(Bucket=bucket)["Policy"] == policy
+
+
+def test_missing_s3_bucket_is_rejected_without_creating_it(s3_client) -> None:
+    bucket = "bakery-missing"
+
+    with pytest.raises(ValueError, match="must already exist"):
+        RootedFilesystem.from_url(f"s3://{bucket}")
+
+    assert bucket not in {
+        item["Name"] for item in s3_client.list_buckets().get("Buckets", [])
+    }
+
+
+@pytest.mark.parametrize("gzip_enabled", [False, True])
+def test_s3_objects_receive_content_metadata(
+    settings, s3_client, gzip_enabled: bool
+) -> None:
+    bucket = f"bakery-metadata-{str(gzip_enabled).lower()}"
+    filesystem_name = f"s3://{bucket}"
+    s3_client.create_bucket(Bucket=bucket)
+    filesystem = RootedFilesystem.from_url(filesystem_name)
+
+    build_snapshot(
+        settings,
+        filesystem,
+        filesystem_name,
+        gzip_enabled=gzip_enabled,
+    )
+
+    html = s3_client.head_object(Bucket=bucket, Key="site/pages/index.html")
+    css = s3_client.head_object(Bucket=bucket, Key="site/static/test.css")
+    javascript = s3_client.head_object(Bucket=bucket, Key="site/media/bar.js")
+    other = s3_client.head_object(Bucket=bucket, Key="site/static/foo.bar")
+
+    assert html["ContentType"] == "text/html"
+    assert css["ContentType"] == "text/css"
+    assert javascript["ContentType"] == "text/javascript"
+    assert other["ContentType"] == "application/octet-stream"
+    expected_encoding = "gzip" if gzip_enabled else None
+    assert html.get("ContentEncoding") == expected_encoding
+    assert css.get("ContentEncoding") == expected_encoding
+    assert javascript.get("ContentEncoding") is None
+    assert other.get("ContentEncoding") is None
 
 
 def test_absolute_and_relative_posix_build_paths_share_the_build_prefix(
@@ -380,7 +490,9 @@ class FailingFilesystem:
     def makedirs(self, _path: str) -> None:
         raise AssertionError("The failing write should not need a directory")
 
-    def open(self, _path: str, _mode: str) -> BinaryIO:
+    def open(
+        self, _path: str, _mode: str, *, metadata: ObjectMetadata | None = None
+    ) -> BinaryIO:
         raise OSError("backend unavailable")
 
     def removetree(self, _path: str) -> None:
@@ -591,13 +703,16 @@ class RecordingFilesystem:
     def exists(self, _path: str) -> bool:
         return False
 
+    def info(self, _path: str) -> object:
+        raise AssertionError("This test only resolves paths")
+
     def makedirs(self, _path: str, exist_ok: bool) -> None:
         assert exist_ok
 
-    def open(self, _path: str, _mode: str) -> BinaryIO:
+    def open(self, _path: str, _mode: str, **_kwargs: object) -> BinaryIO:
         raise AssertionError("This test only resolves paths")
 
-    def rm(self, _path: str, recursive: bool) -> None:
+    def rm(self, _path: str | list[str], recursive: bool) -> None:
         assert recursive
 
     def copy(self, _source: str, _target: str) -> None:
@@ -605,6 +720,90 @@ class RecordingFilesystem:
 
     def find(self, _path: str) -> list[str]:
         return []
+
+
+class RecordingS3Filesystem:
+    """Record cleanup calls without providing S3 bucket lifecycle methods."""
+
+    def __init__(self) -> None:
+        self.removals: list[tuple[str | list[str], bool]] = []
+
+    def exists(self, _path: str) -> bool:
+        return True
+
+    def info(self, _path: str) -> object:
+        return {}
+
+    def makedirs(self, _path: str, exist_ok: bool) -> None:
+        assert exist_ok
+
+    def open(self, _path: str, _mode: str, **_kwargs: object) -> BinaryIO:
+        raise AssertionError("This test only removes paths")
+
+    def rm(self, path: str | list[str], recursive: bool) -> list[str]:
+        self.removals.append((path, recursive))
+        return list(path) if isinstance(path, list) else [path]
+
+    def copy(self, _source: str, _target: str) -> None:
+        raise AssertionError("This test only removes paths")
+
+    def find(self, _path: str) -> list[str]:
+        return ["bucket", "bucket/stale.txt", "other-bucket/keep.txt"]
+
+
+def test_s3_cleanup_never_removes_a_bucket_or_uses_recursive_deletion() -> None:
+    backend = RecordingS3Filesystem()
+    filesystem = RootedFilesystem(backend, "bucket", s3_bucket="bucket")
+
+    filesystem.removetree(".")
+
+    assert backend.removals == [(["bucket/stale.txt"], False)]
+
+
+class PartialDeleteS3Filesystem(RecordingS3Filesystem):
+    """Model S3's successful request with a failed object deletion."""
+
+    def rm(self, path: str | list[str], recursive: bool) -> list[str]:
+        super().rm(path, recursive)
+        return []
+
+
+def test_s3_cleanup_fails_when_any_object_delete_fails() -> None:
+    filesystem = RootedFilesystem(
+        PartialDeleteS3Filesystem(), "bucket", s3_bucket="bucket"
+    )
+
+    with pytest.raises(OSError, match="Unable to delete all objects"):
+        filesystem.removetree(".")
+
+
+class InaccessibleS3Filesystem:
+    """Raise a specific S3 access error during bucket validation."""
+
+    def __init__(self, error: Exception) -> None:
+        self.error = error
+
+    def info(self, _path: str) -> object:
+        raise self.error
+
+
+@pytest.mark.parametrize(
+    "error",
+    [
+        botocore.exceptions.NoCredentialsError(),
+        botocore.exceptions.EndpointConnectionError(endpoint_url="http://localhost"),
+    ],
+)
+def test_inaccessible_s3_bucket_has_a_clear_configuration_error(
+    monkeypatch, error: Exception
+) -> None:
+    backend = InaccessibleS3Filesystem(error)
+    monkeypatch.setattr("bakery.filesystem.url_to_fs", lambda _url: (backend, ""))
+
+    with pytest.raises(ValueError, match="is not accessible") as exc_info:
+        RootedFilesystem.from_url("s3://bakery-inaccessible")
+
+    assert exc_info.value.__cause__ is error
 
 
 def test_windows_drive_root_from_url_is_unrooted(monkeypatch) -> None:

--- a/bakery/tests/test_filesystem_contract.py
+++ b/bakery/tests/test_filesystem_contract.py
@@ -12,7 +12,7 @@ from unittest.mock import patch
 
 import boto3
 import pytest
-from boto3.exceptions import botocore
+import botocore
 from django.apps import apps
 from django.core.management import call_command
 from django.core.management.base import CommandError

--- a/bakery/tests/test_filesystem_contract.py
+++ b/bakery/tests/test_filesystem_contract.py
@@ -12,7 +12,6 @@ from unittest.mock import patch
 
 import boto3
 import pytest
-import botocore
 from django.apps import apps
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -377,11 +376,25 @@ def test_s3_bucket_root_cleanup_preserves_bucket_configuration(
     assert s3_client.get_bucket_policy(Bucket=bucket)["Policy"] == policy
 
 
-def test_missing_s3_bucket_is_rejected_without_creating_it(s3_client) -> None:
+@pytest.mark.parametrize("command_name", ["build", "unbuild"])
+def test_missing_s3_bucket_is_rejected_without_creating_it(
+    settings, s3_client, command_name: str
+) -> None:
     bucket = "bakery-missing"
+    filesystem_name = f"s3://{bucket}"
+    filesystem = RootedFilesystem.from_url(filesystem_name)
+    settings.BUILD_DIR = "site"
+    settings.BAKERY_FILESYSTEM = filesystem_name
+    settings.BAKERY_VIEWS = (
+        "bakery.tests.test_filesystem_contract.FilesystemContractView",
+    )
+    kwargs = (
+        {"skip_static": True, "skip_media": True} if command_name == "build" else {}
+    )
 
-    with pytest.raises(ValueError, match="must already exist"):
-        RootedFilesystem.from_url(f"s3://{bucket}")
+    with configured_filesystem(filesystem, filesystem_name):
+        with pytest.raises(ValueError, match="must already exist"):
+            call_command(command_name, **kwargs)
 
     assert bucket not in {
         item["Name"] for item in s3_client.list_buckets().get("Buckets", [])
@@ -420,6 +433,31 @@ def test_s3_objects_receive_content_metadata(
     assert css.get("ContentEncoding") == expected_encoding
     assert javascript.get("ContentEncoding") is None
     assert other.get("ContentEncoding") is None
+
+
+def test_s3_passthrough_compression_suffixes_do_not_set_content_encoding(
+    s3_client, tmp_path: Path
+) -> None:
+    bucket = "bakery-passthrough-metadata"
+    s3_client.create_bucket(Bucket=bucket)
+    filesystem = RootedFilesystem.from_url(f"s3://{bucket}")
+    command = Command()
+    command.fs = filesystem
+    command.fs_name = f"s3://{bucket}"
+
+    tarball = tmp_path / "archive.tar.gz"
+    tarball.write_bytes(b"tarball")
+    brotli = tmp_path / "script.js.br"
+    brotli.write_bytes(b"brotli")
+    command.copyfile_and_gzip(str(tarball), "static/archive.tar.gz")
+    command.copyfile_and_gzip(str(brotli), "media/script.js.br")
+
+    archive = s3_client.head_object(Bucket=bucket, Key="static/archive.tar.gz")
+    script = s3_client.head_object(Bucket=bucket, Key="media/script.js.br")
+    assert archive["ContentType"] == "application/x-tar"
+    assert archive.get("ContentEncoding") is None
+    assert script["ContentType"] == "text/javascript"
+    assert script.get("ContentEncoding") is None
 
 
 def test_absolute_and_relative_posix_build_paths_share_the_build_prefix(
@@ -728,13 +766,21 @@ class RecordingFilesystem:
 class RecordingS3Filesystem:
     """Record cleanup calls without providing S3 bucket lifecycle methods."""
 
-    def __init__(self) -> None:
-        self.removals: list[tuple[str | list[str], bool]] = []
+    def __init__(
+        self,
+        paths: list[str] | None = None,
+        response: dict[str, object] | None = None,
+    ) -> None:
+        self.paths = paths or ["bucket", "bucket/stale.txt", "other-bucket/keep.txt"]
+        self.response = response or {"Errors": []}
+        self.deletions: list[dict[str, object]] = []
+        self.info_paths: list[str] = []
 
     def exists(self, _path: str) -> bool:
         return True
 
-    def info(self, _path: str) -> object:
+    def info(self, path: str) -> object:
+        self.info_paths.append(path)
         return {}
 
     def makedirs(self, _path: str, exist_ok: bool) -> None:
@@ -743,70 +789,105 @@ class RecordingS3Filesystem:
     def open(self, _path: str, _mode: str, **_kwargs: object) -> BinaryIO:
         raise AssertionError("This test only removes paths")
 
-    def rm(self, path: str | list[str], recursive: bool) -> list[str]:
-        self.removals.append((path, recursive))
-        return list(path) if isinstance(path, list) else [path]
-
     def copy(self, _source: str, _target: str) -> None:
         raise AssertionError("This test only removes paths")
 
     def find(self, _path: str) -> list[str]:
-        return ["bucket", "bucket/stale.txt", "other-bucket/keep.txt"]
+        return self.paths
+
+    def call_s3(self, method: str, **kwargs: object) -> dict[str, object]:
+        assert method == "delete_objects"
+        self.deletions.append(kwargs)
+        return self.response
 
 
-def test_s3_cleanup_never_removes_a_bucket_or_uses_recursive_deletion() -> None:
+def test_s3_cleanup_uses_literal_keys_without_bucket_lifecycle_calls() -> None:
     backend = RecordingS3Filesystem()
     filesystem = RootedFilesystem(backend, "bucket", s3_bucket="bucket")
 
     filesystem.removetree(".")
 
-    assert backend.removals == [(["bucket/stale.txt"], False)]
+    assert backend.deletions == [
+        {
+            "Bucket": "bucket",
+            "Delete": {"Objects": [{"Key": "stale.txt"}], "Quiet": False},
+        }
+    ]
 
 
-class PartialDeleteS3Filesystem(RecordingS3Filesystem):
-    """Model S3's successful request with a failed object deletion."""
-
-    def rm(self, path: str | list[str], recursive: bool) -> list[str]:
-        super().rm(path, recursive)
-        return []
-
-
-def test_s3_cleanup_fails_when_any_object_delete_fails() -> None:
-    filesystem = RootedFilesystem(
-        PartialDeleteS3Filesystem(), "bucket", s3_bucket="bucket"
+def test_s3_cleanup_deletes_literal_special_and_slash_only_keys() -> None:
+    backend = RecordingS3Filesystem(
+        [
+            "bucket",
+            "bucket/",
+            "bucket//",
+            "bucket///",
+            "bucket/normal",
+            "bucket/literal*key",
+            "bucket/literal?key",
+            "bucket/literal[key]",
+        ]
     )
+    filesystem = RootedFilesystem(backend, "bucket", s3_bucket="bucket")
 
-    with pytest.raises(OSError, match="Unable to delete all objects"):
+    filesystem.removetree(".")
+
+    assert backend.deletions == [
+        {
+            "Bucket": "bucket",
+            "Delete": {
+                "Objects": [
+                    {"Key": "/"},
+                    {"Key": "//"},
+                    {"Key": "normal"},
+                    {"Key": "literal*key"},
+                    {"Key": "literal?key"},
+                    {"Key": "literal[key]"},
+                ],
+                "Quiet": False,
+            },
+        }
+    ]
+
+
+def test_s3_cleanup_accepts_empty_deleted_response_from_quiet_mode() -> None:
+    backend = RecordingS3Filesystem(response={"Deleted": [], "Errors": []})
+    filesystem = RootedFilesystem(backend, "bucket", s3_bucket="bucket")
+
+    filesystem.removetree(".")
+
+
+def test_s3_cleanup_fails_when_delete_objects_reports_errors() -> None:
+    backend = RecordingS3Filesystem(
+        response={"Errors": [{"Key": "stale.txt", "Code": "AccessDenied"}]}
+    )
+    filesystem = RootedFilesystem(backend, "bucket", s3_bucket="bucket")
+
+    with pytest.raises(OSError, match=r"stale\.txt"):
         filesystem.removetree(".")
 
 
-class InaccessibleS3Filesystem:
-    """Raise a specific S3 access error during bucket validation."""
+def test_s3_cleanup_batches_more_than_one_thousand_literal_keys() -> None:
+    backend = RecordingS3Filesystem([f"bucket/object-{index}" for index in range(1001)])
+    filesystem = RootedFilesystem(backend, "bucket", s3_bucket="bucket")
 
-    def __init__(self, error: Exception) -> None:
-        self.error = error
+    filesystem.removetree(".")
 
-    def info(self, _path: str) -> object:
-        raise self.error
+    assert [len(deletion["Delete"]["Objects"]) for deletion in backend.deletions] == [
+        1000,
+        1,
+    ]
 
 
-@pytest.mark.parametrize(
-    "error",
-    [
-        botocore.exceptions.NoCredentialsError(),
-        botocore.exceptions.EndpointConnectionError(endpoint_url="http://localhost"),
-    ],
-)
-def test_inaccessible_s3_bucket_has_a_clear_configuration_error(
-    monkeypatch, error: Exception
-) -> None:
-    backend = InaccessibleS3Filesystem(error)
+def test_s3_adapter_construction_does_not_validate_bucket(monkeypatch) -> None:
+    backend = RecordingS3Filesystem()
     monkeypatch.setattr("bakery.filesystem.url_to_fs", lambda _url: (backend, ""))
 
-    with pytest.raises(ValueError, match="is not accessible") as exc_info:
-        RootedFilesystem.from_url("s3://bakery-inaccessible")
+    filesystem = RootedFilesystem.from_url("s3://bakery-inaccessible")
 
-    assert exc_info.value.__cause__ is error
+    assert filesystem.s3_bucket == "bakery-inaccessible"
+    assert backend.info_paths == []
+    assert backend.deletions == []
 
 
 def test_windows_drive_root_from_url_is_unrooted(monkeypatch) -> None:

--- a/bakery/tests/test_filesystem_contract.py
+++ b/bakery/tests/test_filesystem_contract.py
@@ -3,6 +3,7 @@
 import gzip
 import io
 import json
+import mimetypes
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
@@ -411,7 +412,9 @@ def test_s3_objects_receive_content_metadata(
     assert html["ContentType"] == "text/html"
     assert css["ContentType"] == "text/css"
     assert javascript["ContentType"] == "text/javascript"
-    assert other["ContentType"] == "application/octet-stream"
+    assert other["ContentType"] == (
+        mimetypes.guess_type("foo.bar")[0] or "application/octet-stream"
+    )
     expected_encoding = "gzip" if gzip_enabled else None
     assert html.get("ContentEncoding") == expected_encoding
     assert css.get("ContentEncoding") == expected_encoding

--- a/bakery/views/base.py
+++ b/bakery/views/base.py
@@ -23,10 +23,12 @@ from django.views.generic import RedirectView, TemplateView
 
 from bakery import DEFAULT_GZIP_CONTENT_TYPES
 from bakery.filesystem import (
+    ObjectMetadata,
     RootedFilesystem,
     is_root_path,
     join_path,
     normalize_path,
+    object_metadata,
 )
 from bakery.management.commands import get_s3_client
 
@@ -41,7 +43,9 @@ class _WritableFilesystem(Protocol):
 
     def makedirs(self, path: str) -> None: ...
 
-    def open(self, path: str, mode: str) -> BinaryIO: ...
+    def open(
+        self, path: str, mode: str, *, metadata: ObjectMetadata | None = None
+    ) -> BinaryIO: ...
 
     def removetree(self, path: str) -> None: ...
 
@@ -141,7 +145,9 @@ class BuildableMixin:
         Writes out the provided HTML to the provided path.
         """
         logger.debug("Building to %s%s", self.fs_name, target_path)
-        with self.fs.open(smart_str(target_path), "wb") as outfile:
+        with self.fs.open(
+            smart_str(target_path), "wb", metadata=object_metadata(target_path)
+        ) as outfile:
             outfile.write(html)
 
     def is_gzippable(self, target_path: BuildPath) -> bool:
@@ -180,7 +186,12 @@ class BuildableMixin:
             f.write(html)
 
         # Write that buffer out to the filesystem
-        with self.fs.open(smart_str(target_path), "wb") as outfile:
+        metadata = object_metadata(target_path)
+        with self.fs.open(
+            smart_str(target_path),
+            "wb",
+            metadata=ObjectMetadata(metadata.content_type, "gzip"),
+        ) as outfile:
             outfile.write(data_buffer.getvalue())
 
 

--- a/docs/settingsvariables.md
+++ b/docs/settingsvariables.md
@@ -77,6 +77,17 @@ BUILD_DIR = os.path.join(__file__, "build")
         # s3://my-bucket/releases/current/site/
         BAKERY_FILESYSTEM = "s3://my-bucket/releases/current"
 
+    The configured bucket must already exist and Bakery must be able to access
+    it. Bakery never creates or deletes S3 buckets. When a build or unbuild
+    targets a bucket root, Bakery removes the selected output objects one by one
+    while preserving the bucket and its configuration, including policies and
+    website settings. A configured prefix is cleaned independently and never
+    removes sibling prefixes.
+
+    Direct S3 output sets each object's content type from its filename. When
+    ``BAKERY_GZIP`` creates compressed output, Bakery also sets
+    ``Content-Encoding: gzip`` while retaining the original content type.
+
     `s3fs <https://s3fs.readthedocs.io/>`_ uses the standard AWS credential
     and configuration chain. Configure credentials, region, profiles, and
     custom endpoints outside Django with the mechanisms supported by the AWS

--- a/docs/settingsvariables.md
+++ b/docs/settingsvariables.md
@@ -78,15 +78,18 @@ BUILD_DIR = os.path.join(__file__, "build")
         BAKERY_FILESYSTEM = "s3://my-bucket/releases/current"
 
     The configured bucket must already exist and Bakery must be able to access
-    it. Bakery never creates or deletes S3 buckets. When a build or unbuild
-    targets a bucket root, Bakery removes the selected output objects one by one
-    while preserving the bucket and its configuration, including policies and
-    website settings. A configured prefix is cleaned independently and never
-    removes sibling prefixes.
+    it. Bakery checks this when a build or unbuild starts, rather than while
+    Django loads the application. Bakery never creates or deletes S3 buckets.
+    When a build or unbuild targets a bucket root, Bakery removes the selected
+    output objects one by one while preserving the bucket and its
+    configuration, including policies and website settings. A configured prefix
+    is cleaned independently and never removes sibling prefixes.
 
     Direct S3 output sets each object's content type from its filename. When
     ``BAKERY_GZIP`` creates compressed output, Bakery also sets
     ``Content-Encoding: gzip`` while retaining the original content type.
+    Copied files, including files that already have a compression suffix, only
+    receive a content type.
 
     `s3fs <https://s3fs.readthedocs.io/>`_ uses the standard AWS credential
     and configuration chain. Configure credentials, region, profiles, and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [{ name = "Ben Welsh", email = "b@palewi.re" }]
 dependencies = [
     "Django>=5.2,<6.2",
     "boto3>=1.4.4",
+    "botocore>=1.4.4",
     "fsspec>=2026.7.0",
 ]
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -974,6 +974,7 @@ name = "django-bakery"
 source = { editable = "." }
 dependencies = [
     { name = "boto3" },
+    { name = "botocore" },
     { name = "django", version = "5.2.17", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "django", version = "6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "fsspec" },
@@ -1020,6 +1021,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "boto3", specifier = ">=1.4.4" },
+    { name = "botocore", specifier = ">=1.4.4" },
     { name = "celery", marker = "extra == 'celery'", specifier = ">=5.5" },
     { name = "django", specifier = ">=5.2,<6.2" },
     { name = "fsspec", specifier = ">=2026.7.0" },


### PR DESCRIPTION
## Summary

Hardens direct S3 output without performing network validation while Django loads.

- `build` and `unbuild` validate an existing, accessible S3 bucket before any backend write or cleanup. Bakery never creates or deletes buckets.
- Cleanup enumerates contained keys, converts them to bucket-relative literal keys, and calls the configured s3fs client's `DeleteObjects` API with `Quiet=False`. It checks only the response's `Errors`; it never uses generic `rm`, wildcards, recursive removal, or bucket lifecycle APIs.
- S3 output receives inferred `Content-Type`. Only Bakery-generated gzip receives `Content-Encoding: gzip`; copied `.tar.gz` and `.br` files retain content type only.

## Safety coverage

- Moto exercises bucket-root and prefix cleanup, normal output metadata, generated gzip metadata, and missing-bucket command failures.
- Recording backends cover real quiet-mode success semantics (no `Deleted` entries), per-object delete errors, 1,000-key batching, literal `*`, `?`, and `[` keys, plus `/` and `//` object keys. The backend exposes no generic remove or bucket lifecycle operation.
- Adapter creation does not validate the bucket; validation starts only at build/unbuild command boundaries.

## Limitation

Moto does not reproduce S3's quiet delete response. The recording contract therefore supplies an empty successful delete response and verifies that cleanup relies on explicit `Errors` from `DeleteObjects`, not s3fs `rm()` return values.

## Validation

`make verify`, `make hooks`, and a clean Python 3.14/setuptools 84 wheel import pass.