### PR TITLE
test: cover Windows build paths

### DIFF
--- a/bakery/tests/test_filesystem_contract.py
+++ b/bakery/tests/test_filesystem_contract.py
@@ -13,6 +13,7 @@ import pytest
 from django.apps import apps
 from django.core.management import call_command
 from django.core.management.base import CommandError
+from fsspec.implementations.memory import MemoryFileSystem
 from moto.server import ThreadedMotoServer
 from s3fs import S3FileSystem
 
@@ -24,6 +25,11 @@ from bakery.views.base import BuildableMixin
 
 class FilesystemContractView(BuildableTemplateView):
     build_path = "pages/index.html"
+    template_name = "templateview.html"
+
+
+class WindowsFilesystemContractView(BuildableTemplateView):
+    build_path = r"pages\nested\index.html"
     template_name = "templateview.html"
 
 
@@ -615,6 +621,28 @@ def test_windows_drive_root_from_url_is_unrooted(monkeypatch) -> None:
 
     assert filesystem.root == ""
     assert filesystem._resolve("C:/site/index.html") == "C:/site/index.html"
+
+
+def test_windows_drive_build_directory_and_paths_are_platform_independent(
+    settings, monkeypatch
+) -> None:
+    backend: _Filesystem = MemoryFileSystem()
+    monkeypatch.setattr("bakery.filesystem.url_to_fs", lambda _url: (backend, "C:/"))
+    filesystem = RootedFilesystem.from_url("osfs:///")
+    settings.BUILD_DIR = r"C:\bakery-output"
+    settings.BAKERY_FILESYSTEM = "osfs:///"
+    settings.BAKERY_VIEWS = (
+        "bakery.tests.test_filesystem_contract.WindowsFilesystemContractView",
+    )
+
+    with configured_filesystem(filesystem, "osfs:///"):
+        call_command("build", skip_static=True, skip_media=True)
+        output = filesystem_snapshot(filesystem)
+
+    assert filesystem.root == ""
+    assert (
+        output["C:/bakery-output/pages/nested/index.html"] == b"Hell\xc5\x8d tests!\n"
+    )
 
 
 @pytest.mark.parametrize("url", ["ftp://example.com/output"])


### PR DESCRIPTION
## Summary
- verify a drive-qualified Windows `BUILD_DIR` works through the fsspec adapter
- verify Windows-style output paths are normalized during a complete build

The fsspec migration on `main` already resolves the reported production behavior; this PR adds platform-neutral regression coverage.

## Validation
- `make test TEST_ARGS='bakery/tests/test_filesystem_contract.py'`
- `make lint`
- `make format-check`
- `make type-check`

Closes #134
Closes #158