### PR TITLE
Add buildable error views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to django-bakery are documented here. The format follows
 
 - Add optional rooted Amazon S3 build output with
   `BAKERY_FILESYSTEM="s3://bucket[/prefix]"`.
+- Add buildable 400, 403, and 500 error-page views alongside the existing 404 view.
 - Add a uv-based development container and worktree-aware bootstrap command.
 - Add contributor, agent, release, and security guidance.
 

--- a/bakery/tests/__init__.py
+++ b/bakery/tests/__init__.py
@@ -338,13 +338,19 @@ class BakeryTest(TestCase):
         build_path = Path(settings.BUILD_DIR).joinpath("detail/badurl.html")
         assert build_path.exists()
 
-    def test_404_view(self):
-        v = views.Buildable404View()
-        assert v.build_method
-        v.build()
-        build_path = Path(settings.BUILD_DIR).joinpath("404.html")
-        assert build_path.exists()
-        build_path.unlink()
+    def test_error_views(self):
+        for view_class, build_name in (
+            (views.Buildable400View, "400.html"),
+            (views.Buildable403View, "403.html"),
+            (views.Buildable404View, "404.html"),
+            (views.Buildable500View, "500.html"),
+        ):
+            view = view_class(template_name="404.html")
+            assert view.build_method
+            view.build()
+            build_path = Path(settings.BUILD_DIR).joinpath(build_name)
+            assert build_path.exists()
+            build_path.unlink()
 
     def test_json_view(self):
         v = MockJSONView()
@@ -407,7 +413,7 @@ class BakeryTest(TestCase):
             self.test_template_view_with_reversed_nested_directory_and_explicit_filename()
             self.test_list_view()
             self.test_detail_view()
-            self.test_404_view()
+            self.test_error_views()
             self.test_build_cmd()
 
     def test_buildserver_cmd(self):

--- a/bakery/views/__init__.py
+++ b/bakery/views/__init__.py
@@ -1,5 +1,8 @@
 from .base import (
+    Buildable400View,
+    Buildable403View,
     Buildable404View,
+    Buildable500View,
     BuildableMixin,
     BuildableRedirectView,
     BuildableTemplateView,
@@ -14,7 +17,10 @@ from .detail import BuildableDetailView
 from .list import BuildableListView
 
 __all__ = (
+    "Buildable400View",
+    "Buildable403View",
     "Buildable404View",
+    "Buildable500View",
     "BuildableArchiveIndexView",
     "BuildableDayArchiveView",
     "BuildableDetailView",

--- a/bakery/views/base.py
+++ b/bakery/views/base.py
@@ -217,13 +217,36 @@ class BuildableTemplateView(TemplateView, BuildableMixin):
         return normalize_path(self.build_path).lstrip("/")
 
 
-class Buildable404View(BuildableTemplateView):
-    """
-    The default Django 404 page, but built out.
-    """
+class _BuildableErrorView(BuildableTemplateView):
+    """Base class for static pages matching Django's default error templates."""
+
+
+class Buildable400View(_BuildableErrorView):
+    """The default Django 400 page, but built out."""
+
+    build_path = "400.html"
+    template_name = "400.html"
+
+
+class Buildable403View(_BuildableErrorView):
+    """The default Django 403 page, but built out."""
+
+    build_path = "403.html"
+    template_name = "403.html"
+
+
+class Buildable404View(_BuildableErrorView):
+    """The default Django 404 page, but built out."""
 
     build_path = "404.html"
     template_name = "404.html"
+
+
+class Buildable500View(_BuildableErrorView):
+    """The default Django 500 page, but built out."""
+
+    build_path = "500.html"
+    template_name = "500.html"
 
 
 class BuildableRedirectView(RedirectView, BuildableMixin):

--- a/docs/buildableviews.md
+++ b/docs/buildableviews.md
@@ -472,24 +472,33 @@ Django's [class-based views](https://docs.djangoproject.com/en/dev/topics/class-
 
 ```
 
-## Buildable404View
+## Buildable error views
 
 ```{eval-rst}
+.. class:: Buildable400View(BuildableTemplateView)
+.. class:: Buildable403View(BuildableTemplateView)
 .. class:: Buildable404View(BuildableTemplateView)
+.. class:: Buildable500View(BuildableTemplateView)
 
-    Renders and builds a simple 404 error page template as a flat file. Extended from the ``BuildableTemplateView`` above.
-    The base class has a number of options not documented here you should consult.
+    Render and build static pages for Django's standard 400, 403, 404, and 500
+    error templates. Add the views you need to ``BAKERY_VIEWS``. Each class uses
+    the matching ``<status>.html`` template and writes ``<status>.html`` at the
+    build root by default. Override ``template_name`` or ``build_path`` to use a
+    different location.
 
-    **All it does**
+    **Example myapp/views.py**
 
     .. code-block:: python
 
-        from bakery.views import BuildableTemplateView
+        from bakery.views import Buildable404View, Buildable500View
 
 
-        class Buildable404View(BuildableTemplateView):
-            build_path = "404.html"
-            template_name = "404.html"
+        class Static404View(Buildable404View):
+            pass
+
+
+        class Static500View(Buildable500View):
+            pass
 
 ```
 


### PR DESCRIPTION
## Summary
- add buildable 400, 403, and 500 views alongside the existing 404 view
- export and document the error-page views
- cover default error-page output paths

Closes #121