### PR TITLE
Update documentation theme

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -23,6 +23,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install uv
@@ -60,6 +61,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Install uv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to django-bakery are documented here. The format follows
 
 ### Fixed
 
+- Update the documentation theme to fix sidebar rendering in Sphinx 9, and
+  build deployed documentation with accurate setuptools-scm version metadata.
+
 ### Removed
 
 ### Security

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,6 +14,12 @@ project = distribution["Name"]
 author = distribution.get("Author") or distribution.get("Author-email", "")
 version = distribution_version("django-bakery")
 release = version
+if version.startswith("0.1.dev"):
+    msg = (
+        "django-bakery documentation received a setuptools-scm fallback version. "
+        "Build from a checkout with Git tags and history."
+    )
+    raise RuntimeError(msg)
 year = datetime.now(UTC).year
 copyright = f"{year}, {author}"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ docs = [
     "myst-parser",
     "sphinx",
     "sphinx-autobuild",
-    "sphinx-palewire-theme",
+    "sphinx-palewire-theme>=0.1.4",
 ]
 
 [tool.setuptools]

--- a/uv.lock
+++ b/uv.lock
@@ -1046,7 +1046,7 @@ docs = [
     { name = "myst-parser" },
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
-    { name = "sphinx-palewire-theme" },
+    { name = "sphinx-palewire-theme", specifier = ">=0.1.4" },
 ]
 test = [
     { name = "celery", specifier = ">=5.5" },
@@ -2991,13 +2991,13 @@ wheels = [
 
 [[package]]
 name = "sphinx-palewire-theme"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/3c/85c0e4beaaab9c4135be304878ca484ba230558b00f30a2778af925f4909/sphinx_palewire_theme-0.1.3.tar.gz", hash = "sha256:d02cfdc4b6f857de398477a85af4a7844c5eadfba252a632458ec1298e387ab8", size = 12638, upload-time = "2026-02-17T01:08:49.247Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ef/d75a34782abafba6fdbbef5d456292e702396160d18b2e47c25e57e93913/sphinx_palewire_theme-0.1.4.tar.gz", hash = "sha256:608ff8645130f0a44cb59853c558a434468ae3253ea7c0803855e0e449da7644", size = 14731, upload-time = "2026-08-25T12:54:45.338Z" }
 
 [[package]]
 name = "sphinxcontrib-applehelp"


### PR DESCRIPTION
## Summary

The docs dependency was unversioned, so the lock retained `sphinx-palewire-theme` 0.1.3 and missed its Sphinx 9 sidebar/search fix. The documentation workflow also used shallow checkouts, preventing setuptools-scm from reading the `v0.14.0` tag and causing the deployed `0.1.dev...` fallback version.

This requires theme 0.1.4, refreshes only its lock entry, fetches full history for both Sphinx documentation jobs, and fails a docs build if the known fallback version is used.

## Related Issue

N/A

## Change Type

- [x] Bug fix
- [x] Documentation
- [x] Maintenance

## Acceptance Criteria

- [x] The docs use `sphinx-palewire-theme` 0.1.4 and its generated CSS.
- [x] Documentation builds from a tagged checkout report a `0.14.x`-derived version instead of `0.1.dev...`.

## Validation

- `make docs-check`
- `make verify`
- `make hooks`
- Built docs after reinstalling package metadata from this committed full-tag checkout: `0.14.1.dev1+g2685dd757`; generated HTML references `_static/palewire.css`.
- Verified the fallback guard rejects `0.1.dev1+gdeadbeef`, plus generated sidebar/search markup and responsive sidebar/search CSS selectors.

## Documentation and Release Notes

- [x] Documentation workflow is updated.
- [x] `CHANGELOG.md` is updated.