### PR TITLE
Use page-level documentation navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to django-bakery are documented here. The format follows
 
 - Update the documentation theme to fix sidebar rendering in Sphinx 9, and
   build deployed documentation with accurate setuptools-scm version metadata.
+- Show links to documentation pages in the desktop sidebar, reserve Previous
+  and Next pagination for smaller screens, and prevent responsive overflow.
 
 ### Removed
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ CHECK_WHEEL_IGNORE ?= W002
 RUN = $(if $(UV_PYTHON),UV_PYTHON=$(UV_PYTHON)) $(UV) run --no-env-file
 TEST_RUN = $(RUN) $(if $(DJANGO),--with "$(DJANGO)")
 
-.PHONY: all help bootstrap install install-all install-dev install-test install-docs check verify diff-check lint format-check format fix type-check dependency-check workflow-check manifest-check test coverage build package-check package-verify docs docs-check linkcheck serve-docs hooks clean
+.PHONY: all help bootstrap install install-all install-dev install-test install-docs check verify diff-check lint format-check format fix type-check dependency-check workflow-check manifest-check test coverage build package-check package-verify docs docs-check docs-navigation-check linkcheck serve-docs hooks clean
 
 help: ## Show available commands
 	@awk 'BEGIN {FS = ":.*## "}; /^[a-zA-Z0-9_-]+:.*## / {printf "%-18s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -98,6 +98,10 @@ docs: ## Build HTML documentation
 
 docs-check: ## Build documentation and fail on warnings
 	$(RUN) sphinx-build -M html docs docs/_build -W --keep-going
+	$(MAKE) docs-navigation-check
+
+docs-navigation-check: ## Check generated documentation navigation
+	$(RUN) python scripts/check_docs_navigation.py docs/_build/html
 
 linkcheck: ## Check documentation links
 	$(RUN) sphinx-build -M linkcheck docs docs/_build -W --keep-going

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,3 +63,4 @@ html_theme = "palewire"
 html_theme_options = {
     "canonical_url": "https://palewi.re/docs/django-bakery/",
 }
+html_sidebars = {"**": ["navigation.html", "searchbox.html"]}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ docs = [
     "myst-parser",
     "sphinx",
     "sphinx-autobuild",
-    "sphinx-palewire-theme>=0.1.4",
+    "sphinx-palewire-theme>=0.1.5",
 ]
 
 [tool.setuptools]

--- a/scripts/check_docs_navigation.py
+++ b/scripts/check_docs_navigation.py
@@ -1,0 +1,102 @@
+"""Verify the generated documentation navigation contract."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Final
+
+EXPECTED_PAGE_LINKS: Final = {
+    "gettingstarted.html": "Getting started",
+    "buildableviews.html": "Buildable views",
+}
+
+
+class SidebarNavigationParser(HTMLParser):
+    """Collect links rendered inside the desktop documentation navigation."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.in_navigation = False
+        self.links: list[tuple[str, str]] = []
+        self._link_href: str | None = None
+        self._link_text: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attributes = dict(attrs)
+        if tag == "nav" and "sphinxsidebar-navigation" in (
+            attributes.get("class") or ""
+        ):
+            self.in_navigation = True
+        elif self.in_navigation and tag == "a":
+            self._link_href = attributes.get("href")
+            self._link_text = []
+
+    def handle_data(self, data: str) -> None:
+        if self._link_href is not None:
+            self._link_text.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag == "a" and self._link_href is not None:
+            self.links.append((self._link_href, "".join(self._link_text).strip()))
+            self._link_href = None
+        elif tag == "nav" and self.in_navigation:
+            self.in_navigation = False
+
+
+def require(condition: bool, message: str) -> None:
+    """Exit with a clear error if the generated output violates the contract."""
+    if not condition:
+        raise SystemExit(message)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("build_dir", type=Path)
+    args = parser.parse_args()
+    build_dir: Path = args.build_dir
+
+    navigation = SidebarNavigationParser()
+    navigation.feed((build_dir / "index.html").read_text())
+    page_links = dict(navigation.links)
+
+    for href, title in EXPECTED_PAGE_LINKS.items():
+        require(
+            page_links.get(href) == title,
+            f"Desktop sidebar navigation is missing the {title!r} page link.",
+        )
+    require(
+        not any(href.startswith("#") for href, _ in navigation.links),
+        "Desktop sidebar navigation must not contain current-page section anchors.",
+    )
+
+    stylesheet = (build_dir / "_static" / "palewire.css").read_text()
+    require(
+        re.search(r"nav#rellinks\s*\{\s*display:\s*none;", stylesheet) is not None,
+        "Desktop pagination must be hidden by default.",
+    )
+    require(
+        re.search(
+            r"@media\s+screen\s+and\s+\(max-width:\s*975px\)\s*\{\s*"
+            r"nav#rellinks\s*\{\s*display:\s*block;",
+            stylesheet,
+        )
+        is not None,
+        "Pagination must be visible when the desktop sidebar is hidden.",
+    )
+    require(
+        re.search(
+            r"@media\s+screen\s+and\s+\(max-width:\s*975px\)\s*\{\s*"
+            r"div\.document,\s*div\.document\.wide,\s*div\.document\.narrow\s*"
+            r"\{\s*width:\s*100%;",
+            stylesheet,
+        )
+        is not None,
+        "The document must become fluid when the desktop sidebar is hidden.",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/uv.lock
+++ b/uv.lock
@@ -1046,7 +1046,7 @@ docs = [
     { name = "myst-parser" },
     { name = "sphinx" },
     { name = "sphinx-autobuild" },
-    { name = "sphinx-palewire-theme", specifier = ">=0.1.4" },
+    { name = "sphinx-palewire-theme", specifier = ">=0.1.5" },
 ]
 test = [
     { name = "celery", specifier = ">=5.5" },
@@ -2991,13 +2991,13 @@ wheels = [
 
 [[package]]
 name = "sphinx-palewire-theme"
-version = "0.1.4"
+version = "0.1.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "sphinx", version = "9.0.4", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
     { name = "sphinx", version = "9.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/ef/d75a34782abafba6fdbbef5d456292e702396160d18b2e47c25e57e93913/sphinx_palewire_theme-0.1.4.tar.gz", hash = "sha256:608ff8645130f0a44cb59853c558a434468ae3253ea7c0803855e0e449da7644", size = 14731, upload-time = "2026-08-25T12:54:45.338Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/47/4f34afe49703d55d6bf82fd7ff2a767e5ca14b33cadfaf08bbaa0b1990f9/sphinx_palewire_theme-0.1.5.tar.gz", hash = "sha256:9ae9e2dd4321551489b34bde525ce97548f9b15d67ce39fdb358e56bf9d265a9", size = 15647, upload-time = "2026-08-25T13:52:14.484Z" }
 
 [[package]]
 name = "sphinxcontrib-applehelp"


### PR DESCRIPTION
## Summary
- Update the documentation theme to sphinx-palewire-theme 0.1.5.
- Render only page-level navigation and search in the desktop sidebar.
- Keep Previous/Next links on narrow screens and verify the 975px fluid layout.
- Add a generated-output check for sidebar links, mobile pagination, and responsive width.

## Validation
- `make verify`
- `make hooks`
- `make docs-check`

The committed docs build reports `0.14.1.dev3+g3388c1a58` from full Git history and tags.